### PR TITLE
feat: support XDG_CONFIG_HOME variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,9 @@ The concept of the trashcan does not exist in Command-line interface ([CLI](http
 - Compatible with `rm` command, e.g. `-r`, `-f` options
 - Nice UI, awesome CLI UX
 - Easy to see what gomi does with setting `GOMI_LOG=[trace|debug|info|warn|error]`
+- Trashcan can be located under
+    - `$XDG_CONFIG_HOME/gomi`
+    - `$HOME/.gomi`
 
 ## Usage
 

--- a/main.go
+++ b/main.go
@@ -25,19 +25,28 @@ import (
 	"golang.org/x/sync/errgroup"
 )
 
-const gomiDir = ".gomi"
-
 // These variables are set in build step
 var (
 	Version  = "unset"
 	Revision = "unset"
 )
 
-var (
-	gomiPath      = filepath.Join(os.Getenv("HOME"), gomiDir)
-	inventoryFile = "inventory.json"
-	inventoryPath = filepath.Join(gomiPath, inventoryFile)
-)
+var gomiPath string
+var inventoryPath string
+
+// Load Gomi Path from environment variable
+// $XDG_CONFIG_HOME/gomi > $HOME/.gomi
+func init() {
+	gomiDir := "gomi"
+  inventoryFile := "inventory.json"
+	if os.Getenv("XDG_CONFIG_HOME") != "" {
+		gomiPath = filepath.Join(os.Getenv("XDG_CONFIG_HOME"), gomiDir)
+    inventoryPath = filepath.Join(gomiPath, inventoryFile)
+	} else {
+		gomiPath = filepath.Join(os.Getenv("HOME"), "."+gomiDir)
+    inventoryPath = filepath.Join(gomiPath, inventoryFile)
+	}
+}
 
 // Option represents application options
 type Option struct {


### PR DESCRIPTION
The `XDG_CONFIG_HOME` environment variable is defined by the FreeDesktop.org Base Directory specification, which aims to provide a unified and consistent way for applications to store user-specific data. By using this environment variable, `gomi` is following the specification, which helps prevent cluttering the user's home directory with configuration files.

Instead, `gomi` will create its own subdirectory within the directory specified by `XDG_CONFIG_HOME`. This ensures that the user's home directory remains organized and tidy, and makes it easier for users to manage and locate application-specific configuration files.