### PR TITLE
Fixed a bug that added empty elements & changed to serial processing

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -10,7 +10,6 @@ require (
 	github.com/manifoldco/promptui v0.7.0
 	github.com/rs/xid v1.2.1
 	golang.org/x/crypto v0.0.0-20200117160349-530e935923ad
-	golang.org/x/sync v0.0.0-20190911185100-cd5d95a43a6e
 )
 
 require (

--- a/go.mod
+++ b/go.mod
@@ -10,6 +10,7 @@ require (
 	github.com/manifoldco/promptui v0.7.0
 	github.com/rs/xid v1.2.1
 	golang.org/x/crypto v0.0.0-20200117160349-530e935923ad
+	golang.org/x/exp v0.0.0-20230510235704-dd950f8aeaea
 )
 
 require (

--- a/go.sum
+++ b/go.sum
@@ -62,6 +62,8 @@ golang.org/x/crypto v0.0.0-20181203042331-505ab145d0a9/go.mod h1:6SG95UA2DQfeDnf
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
 golang.org/x/crypto v0.0.0-20200117160349-530e935923ad h1:Jh8cai0fqIK+f6nG0UgPW5wFk8wmiMhM3AyciDBdtQg=
 golang.org/x/crypto v0.0.0-20200117160349-530e935923ad/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
+golang.org/x/exp v0.0.0-20230510235704-dd950f8aeaea h1:vLCWI/yYrdEHyN2JzIzPO3aaQJHQdp89IZBA/+azVC4=
+golang.org/x/exp v0.0.0-20230510235704-dd950f8aeaea/go.mod h1:V1LtkGg67GoY2N1AnLN78QLrzxkLyJw7RJb1gzOOz9w=
 golang.org/x/net v0.0.0-20190404232315-eb5bcb51f2a3/go.mod h1:t9HGtf8HONx5eT2rtn7q6eTqICYqUVnKs3thJo3Qplg=
 golang.org/x/sys v0.0.0-20181122145206-62eef0e2fa9b/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20181205085412-a5c9d58dba9a/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=

--- a/go.sum
+++ b/go.sum
@@ -63,8 +63,6 @@ golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACk
 golang.org/x/crypto v0.0.0-20200117160349-530e935923ad h1:Jh8cai0fqIK+f6nG0UgPW5wFk8wmiMhM3AyciDBdtQg=
 golang.org/x/crypto v0.0.0-20200117160349-530e935923ad/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
 golang.org/x/net v0.0.0-20190404232315-eb5bcb51f2a3/go.mod h1:t9HGtf8HONx5eT2rtn7q6eTqICYqUVnKs3thJo3Qplg=
-golang.org/x/sync v0.0.0-20190911185100-cd5d95a43a6e h1:vcxGaoTs7kV8m5Np9uUNQin4BrLOthgV7252N8V+FwY=
-golang.org/x/sync v0.0.0-20190911185100-cd5d95a43a6e/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sys v0.0.0-20181122145206-62eef0e2fa9b/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20181205085412-a5c9d58dba9a/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=

--- a/main.go
+++ b/main.go
@@ -54,11 +54,11 @@ type Option struct {
 // RmOption represents rm command option
 // This should be not conflicts with app option
 type RmOption struct {
-	Interactive bool `short:"i" description:"To make compatible with rm command"`
-	Recursive   bool `short:"r" description:"To make compatible with rm command"`
+	Interactive bool `short:"i" description:"To make compatible with rm command (dummy)"`
+	Recursive   bool `short:"r" description:"To make compatible with rm command (dummy)"`
 	Force       bool `short:"f" description:"To make compatible with rm command"`
-	Directory   bool `short:"d" description:"To make compatible with rm command"`
-	Verbose     bool `short:"v" description:"To make compatible with rm command"`
+	Directory   bool `short:"d" description:"To make compatible with rm command (dummy)"`
+	Verbose     bool `short:"v" description:"To make compatible with rm command (dummy)"`
 }
 
 // Inventory represents the log data of deleted objects


### PR DESCRIPTION
Thank you for creating the useful software.

I fixed the bug where garbage data was being written to the inventory file when I deleted a non-existent file or a file not allowed by permissions.
https://github.com/b4b4r07/gomi/commit/cebc3726f899abb4b44d574db9e38bf81ed6737d

The cause is that it is initializing the files local variable in the Remove() method with the number of args.

Cause
```
files := make([]File, len(args)) # Allocate number array of args

defer c.Inventory.Save(files)    # writing in the number of args at the time of error
return eg.Wait()                 # immediately return if some files do not exist
```

<details>
<summary>How to reproduce</summary>

```
$ touch a1

# Error because a2 does not exist
$ gomi a2 a1
a2: no such file or directory

# garbage element is added at the end.
$ jq < ~/.gomi/inventory.json | jq '.files[-2,-1]'
{
  "name": "",
  "id": "",
  "group_id": "",
  "from": "",
  "to": "",
  "timestamp": "0001-01-01T00:00:00Z"
}
{
  "name": "a1",
  "id": "chfpm5kdpli3njdmn7kg",
  "group_id": "chfpm5kdpli3njdmn7k0",
  "from": "/home/wsl/projects/fork/gomi/dummy/a1",
  "to": "/home/wsl/.gomi/2023/05/13/chfpm5kdpli3njdmn7k0/a1.chfpm5kdpli3njdmn7kg",
  "timestamp": "2023-05-13T23:13:42.169092757+09:00"
}
```

By fixing this, the following process would no longer be needed. (Although turning it off would affect existing users.)
https://github.com/b4b4r07/gomi/blob/e63731adf335293729414d683e68a80f9f8fbd45/main.go#L396-L399
</details>

To fix this, I changed code to serial processing because i felt that parallelization made the code more complex and made it difficult to be consistent with error handling and inventory files.
(Considering the characteristics of the program, i thought it would be better to focus on consistency and integrity.)

Error handling in Remove() has also been modified a bit, as it has been changed to a serial process.

I believe the following problems/conflicts are currently possible due to parallel processing.

* When an error occurs in deleting multiple files, only the first error is displayed.
* When a file that causes an error and a file that can be deleted normally are deleted at the same time, the error occurs and is stopped, but the latter file may or may not be deleted. Even if it deleted, it does not necessarily mean that the inventory file has been written to correctly.


In addition, benchmarking with the sample code at hand also confirmed that the parallelization is rather slow in some cases.
(I confirmed this on linux, but it may be different in other environments.)
(It seems that there is no particular benefit to parallelization since the operation is almost on-memory, just rewriting directory files on the page cache.)

In line with this modification, `RestoreGroup()` is also serialized to unify its internal behavior.
https://github.com/b4b4r07/gomi/commit/754c4b2d6db08759f032b6ab449b3cbc69faf673
https://github.com/b4b4r07/gomi/pull/36/commits/03e42877bdbfaa194b756e56a32da611f028f68f

Since I fixed the bug of entering JSON with an empty structure, I thought it would be ok to remove the process of filtering out invalid logs when the id is empty in `// Filter out invalid logs` , but I haven't changed it because it might affect existing users.

Currently, the -f option ignores all errors, but this was likely to cause problems when permission errors or other errors occur, as they would not be noticed because they would not be displayed.
I checked POSIX rm and confirmed that it only ignores non-existent files and does not set the exit code to 1, but in the case of other errors such as permission errors, the error is displayed and the exit code is set to 1.

https://man7.org/linux/man-pages/man1/rm.1.html

<details>
<summary>How to confirm</summary>

```
$ mkdir d1
$ touch d1/a
$ sudo chown root:root d1

# without -f, it get an error
$ gomi d1/a1; echo $?
rename /home/wsl/projects/fork/gomi/dummy/d1/a1 /home/wsl/.gomi/2023/05/13/chfpk4sdpli3droidrbg/a1.chfpk4sdpli3droidrc0: permission denied
1

# with -f, do not get an error
$ gomi -f d1/a1; echo $?
0

# in case of rm, it get an error
$ rm -rf d1/a1; echo $?
rm: cannot remove 'd1/a1': Permission denied
1
```
</details>

It was not clear that only the -f option was used, so the help message was modified slightly.
https://github.com/b4b4r07/gomi/commit/ba0fd1987b58b5f243c6a2ac007506ac740d52c7

If you have any minor error handling or concerns, I would appreciate it if you could merge them with a cherry pick.



### benchmark with many small files
before (parallel processing)
```
# create 10000 dummy files
$ time for x in {1..10000}; do
  dd if=/dev/zero ibs=1 count=1 of=gomi-$x.txt 2>/dev/null
done
$ echo 3 | sudo tee /proc/sys/vm/drop_caches

# move to gomi
$ time gomi gomi-*.txt
gomi gomi-*.txt
0.25s user
1.36s system
292% cpu
0.552 total

$ echo 3 | sudo tee /proc/sys/vm/drop_caches

# very slow, consume cpu considerably, it seems json encoding cost is very high
$ time gomi -B
gomi -B
61.47s user
12.47s system
112% cpu
1:05.96 total
``` 

after (serial processing, write as batch)
```
# removing is also faster, less cpu
$ time ../gomi-fix gomi-*.txt
../gomi-fix gomi-*.txt
0.08s user
0.16s system
98% cpu
0.242 total

# restore as batch faster
$ time ../gomi-fix -B
../gomi-fix -B
0.24s user
0.13s system
93% cpu
0.391 total
```
