### PR TITLE
Refactor history package

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ github:
   repo: gomi
   release:
     name: gomi
-    tag: v1.2.0
+    tag: v1.2.3
   command:
     link:
     - from: gomi

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -125,9 +125,6 @@ func (c CLI) Run(args []string) error {
 	if err := c.history.Open(); err != nil {
 		return err
 	}
-	defer func() {
-		_ = c.history.Backup()
-	}()
 
 	switch {
 	case c.option.Version:
@@ -290,7 +287,7 @@ func (c CLI) Put(args []string) error {
 
 	// Save the files after all tasks are done
 	defer func() {
-		err := c.history.Save(files)
+		err := c.history.Update(files)
 		if err != nil {
 			slog.Error("failed to update history", "error", err)
 		}


### PR DESCRIPTION
Key Changes:

- `Update` Method: Appends files to the history and overwrites the file.
- `Backup` Logic: Ensures backup before modifying the history file.
- Documentation: Updated version number in the README.


