### PR TITLE
Make moving files across different partitions possible by adding fallback to copy-and-delete

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -1,6 +1,8 @@
 name: Go
 on:
   pull_request:
+    paths:
+    - '**/*.go'
   workflow_dispatch:
 
 jobs:

--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ github:
     alias:
       rm: gomi
 ```
-```console
+```bash
 afx install
 ```
 
@@ -153,7 +153,7 @@ history:
 
 To get extra debug output (not shown in the official help), use the `--debug` flag:
 
-```console
+```bash
 gomi --debug
 ```
 
@@ -161,7 +161,7 @@ This command will stream log output, similar to `tail -f`. While running `gomi -
 
 If you prefer JSON formatted output, use:
 
-```console
+```bash
 gomi --debug=json
 ```
 

--- a/go.mod
+++ b/go.mod
@@ -24,6 +24,7 @@ require (
 	github.com/muesli/reflow v0.3.0
 	github.com/muesli/termenv v0.15.2
 	github.com/nxadm/tail v1.4.11
+	github.com/otiai10/copy v1.14.1
 	github.com/rs/xid v1.6.0
 	github.com/samber/lo v1.47.0
 	golang.org/x/sync v0.10.0
@@ -47,6 +48,7 @@ require (
 	github.com/mattn/go-runewidth v0.0.16 // indirect
 	github.com/muesli/ansi v0.0.0-20230316100256-276c6243b2f6 // indirect
 	github.com/muesli/cancelreader v0.2.2 // indirect
+	github.com/otiai10/mint v1.6.3 // indirect
 	github.com/rivo/uniseg v0.4.7 // indirect
 	github.com/sahilm/fuzzy v0.1.1 // indirect
 	golang.org/x/crypto v0.32.0 // indirect

--- a/go.mod
+++ b/go.mod
@@ -28,6 +28,7 @@ require (
 	github.com/rs/xid v1.6.0
 	github.com/samber/lo v1.47.0
 	golang.org/x/sync v0.10.0
+	golang.org/x/sys v0.29.0
 	gopkg.in/yaml.v2 v2.4.0
 )
 
@@ -54,7 +55,6 @@ require (
 	golang.org/x/crypto v0.32.0 // indirect
 	golang.org/x/exp v0.0.0-20231006140011-7918f672742d // indirect
 	golang.org/x/net v0.34.0 // indirect
-	golang.org/x/sys v0.29.0 // indirect
 	golang.org/x/text v0.21.0 // indirect
 	gopkg.in/tomb.v1 v1.0.0-20141024135613-dd632973f1e7 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -85,6 +85,10 @@ github.com/muesli/termenv v0.15.2 h1:GohcuySI0QmI3wN8Ok9PtKGkgkFIk7y6Vpb5PvrY+Wo
 github.com/muesli/termenv v0.15.2/go.mod h1:Epx+iuz8sNs7mNKhxzH4fWXGNpZwUaJKRS1noLXviQ8=
 github.com/nxadm/tail v1.4.11 h1:8feyoE3OzPrcshW5/MJ4sGESc5cqmGkGCWlco4l0bqY=
 github.com/nxadm/tail v1.4.11/go.mod h1:OTaG3NK980DZzxbRq6lEuzgU+mug70nY11sMd4JXXHc=
+github.com/otiai10/copy v1.14.1 h1:5/7E6qsUMBaH5AnQ0sSLzzTg1oTECmcCmT6lvF45Na8=
+github.com/otiai10/copy v1.14.1/go.mod h1:oQwrEDDOci3IM8dJF0d8+jnbfPDllW6vUjNc3DoZm9I=
+github.com/otiai10/mint v1.6.3 h1:87qsV/aw1F5as1eH1zS/yqHY85ANKVMgkDrf9rcxbQs=
+github.com/otiai10/mint v1.6.3/go.mod h1:MJm72SBthJjz8qhefc4z1PYEieWmy8Bku7CjcAqyUSM=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/rivo/uniseg v0.1.0/go.mod h1:J6wj4VEh+S6ZtnVlnTBMWIodfgj8LQOQFoIToxlJtxc=

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -144,8 +144,8 @@ func (c CLI) Run(args []string) error {
 }
 
 func (c CLI) Restore() error {
-	slog.Debug("cil.restore started")
-	defer slog.Debug("cil.restore finished")
+	slog.Debug("cli.restore started")
+	defer slog.Debug("cli.restore finished")
 
 	if len(c.history.Files) == 0 {
 		fmt.Printf("The history is empty. Let's try deleting a file first\n")
@@ -226,7 +226,7 @@ func (c CLI) Restore() error {
 		if !allowed() {
 			continue
 		}
-		err := os.Rename(file.To, file.From)
+		err := move(file.To, file.From)
 		if err != nil {
 			errs = append(errs, err)
 			slog.Error("failed to restore! file would not be deleted from history file", "error", err)
@@ -248,8 +248,8 @@ func (c CLI) Restore() error {
 }
 
 func (c CLI) Put(args []string) error {
-	slog.Debug("cil.put started")
-	defer slog.Debug("cil.put finished")
+	slog.Debug("cli.put started")
+	defer slog.Debug("cli.put finished")
 
 	if len(args) == 0 {
 		return errors.New("too few arguments")
@@ -276,12 +276,7 @@ func (c CLI) Put(args []string) error {
 			files[i] = file
 			mu.Unlock()
 
-			// Ensure the directory exists before renaming the file
-			_ = os.MkdirAll(filepath.Dir(file.To), 0777)
-
-			// Log the file move
-			slog.Debug("moved", "from", file.From, "to", file.To)
-			return os.Rename(file.From, file.To)
+			return move(file.From, file.To)
 		})
 	}
 

--- a/internal/cli/move.go
+++ b/internal/cli/move.go
@@ -1,0 +1,75 @@
+package cli
+
+import (
+	"fmt"
+	"log/slog"
+	"os"
+	"path/filepath"
+
+	cp "github.com/otiai10/copy"
+)
+
+// copyAndDelete copies a file or directory (recursively) and then deletes the original.
+func copyAndDelete(src, dst string) error {
+	slog.Debug("starting copy and delete operation", "from", src, "to", dst)
+	if err := cp.Copy(src, dst); err != nil {
+		return fmt.Errorf("failed to copy file: %w", err)
+	}
+
+	// If the copy is successful, remove the original file or directory
+	if err := os.Remove(src); err != nil {
+		// If removal of the source fails after copying, attempt to delete the copied file as well
+		if rmErr := os.Remove(dst); rmErr != nil {
+			return fmt.Errorf(
+				"failed to remove both source and destination files: source error: %v, destination error: %v",
+				err, rmErr)
+		}
+		return fmt.Errorf("failed to remove source file after successful copy: %w", err)
+	}
+
+	return nil
+}
+
+// isSamePartition checks if the source and destination reside on the same filesystem partition.
+func isSamePartition(src, dst string) (bool, error) {
+	srcStat, err := os.Stat(src)
+	if err != nil {
+		return false, fmt.Errorf("failed to get source file stats: %w", err)
+	}
+
+	dstStat, err := os.Stat(dst)
+	if err != nil {
+		return false, fmt.Errorf("failed to get destination file stats: %w", err)
+	}
+
+	// Compare the file system identifiers of both files
+	return srcStat.Sys() == dstStat.Sys(), nil
+}
+
+// move attempts to rename a file or directory. If it's on different partitions, it falls back to copying and deleting.
+func move(src, dst string) error {
+	dstDir := filepath.Dir(dst)
+
+	// Ensure the destination directory exists before attempting to move
+	if _, err := os.Stat(dstDir); os.IsNotExist(err) {
+		slog.Debug("mkdir", "dir", dstDir)
+		if err := os.MkdirAll(dstDir, 0777); err != nil {
+			return fmt.Errorf("failed to create destination directory: %w", err)
+		}
+	}
+
+	// Check if source and destination are on the same partition
+	samePartition, err := isSamePartition(src, dstDir)
+	if err != nil {
+		return err
+	}
+	defer slog.Debug("file moved", "from", src, "to", dst)
+
+	// If they are on the same partition, use os.Rename; otherwise, fallback to copy-and-delete
+	if samePartition {
+		return os.Rename(src, dst)
+	}
+
+	slog.Debug("different partitions detected, falling back to copy-and-delete operation")
+	return copyAndDelete(src, dst)
+}

--- a/internal/cli/move.go
+++ b/internal/cli/move.go
@@ -51,7 +51,7 @@ func move(src, dst string) error {
 
 	// If they are on the same partition, use os.Rename; otherwise, fallback to copy-and-delete
 	if samePartition {
-		slog.Debug("removing file with os.Rename")
+		slog.Debug("moving file with os.Rename")
 		return os.Rename(src, dst)
 	}
 

--- a/internal/cli/move.go
+++ b/internal/cli/move.go
@@ -5,7 +5,6 @@ import (
 	"log/slog"
 	"os"
 	"path/filepath"
-	"syscall"
 
 	cp "github.com/otiai10/copy"
 )
@@ -29,33 +28,6 @@ func copyAndDelete(src, dst string) error {
 	}
 
 	return nil
-}
-
-// isSamePartition checks if the source and destination reside on the same filesystem partition.
-func isSamePartition(src, dst string) (bool, error) {
-	srcStat, err := os.Stat(src)
-	if err != nil {
-		return false, fmt.Errorf("failed to get source file stats: %w", err)
-	}
-
-	dstStat, err := os.Stat(dst)
-	if err != nil {
-		return false, fmt.Errorf("failed to get destination file stats: %w", err)
-	}
-
-	srcSys := srcStat.Sys().(*syscall.Stat_t)
-	dstSys := dstStat.Sys().(*syscall.Stat_t)
-
-	// Compare the device identifiers (st_dev) of the source and destination
-	// If the device IDs are the same, the files are on the same partition.
-	samePartition := srcSys.Dev == dstSys.Dev
-
-	slog.Debug("check src/dst file info",
-		"samePartition", samePartition,
-		"src st_dev", srcSys.Dev,
-		"dst st_dev", dstSys.Dev)
-
-	return samePartition, nil
 }
 
 // move attempts to rename a file or directory. If it's on different partitions, it falls back to copying and deleting.

--- a/internal/cli/partition.go
+++ b/internal/cli/partition.go
@@ -1,0 +1,37 @@
+//go:build !windows
+
+package cli
+
+import (
+	"fmt"
+	"log/slog"
+	"os"
+	"syscall"
+)
+
+// isSamePartition checks if the source and destination reside on the same filesystem partition.
+func isSamePartition(src, dst string) (bool, error) {
+	srcStat, err := os.Stat(src)
+	if err != nil {
+		return false, fmt.Errorf("failed to get source file stats: %w", err)
+	}
+
+	dstStat, err := os.Stat(dst)
+	if err != nil {
+		return false, fmt.Errorf("failed to get destination file stats: %w", err)
+	}
+
+	srcSys := srcStat.Sys().(*syscall.Stat_t)
+	dstSys := dstStat.Sys().(*syscall.Stat_t)
+
+	// Compare the device identifiers (st_dev) of the source and destination
+	// If the device IDs are the same, the files are on the same partition.
+	samePartition := srcSys.Dev == dstSys.Dev
+
+	slog.Debug("check src/dst file info",
+		"samePartition", samePartition,
+		"src st_dev", srcSys.Dev,
+		"dst st_dev", dstSys.Dev)
+
+	return samePartition, nil
+}

--- a/internal/cli/partition_windows.go
+++ b/internal/cli/partition_windows.go
@@ -1,0 +1,45 @@
+//go:build windows
+
+package cli
+
+import (
+	"fmt"
+	"log/slog"
+	"os"
+	"path/filepath"
+
+	"golang.org/x/sys/windows"
+)
+
+// isSamePartition checks if the source and destination reside on the same filesystem partition on Windows.
+func isSamePartition(src, dst string) (bool, error) {
+	// Get the volume names (drive letters) for both source and destination paths
+	srcVolume := filepath.VolumeName(src)
+	dstVolume := filepath.VolumeName(dst)
+
+	if srcVolume == "" || dstVolume == "" {
+		return false, fmt.Errorf("failed to determine volume name from file paths")
+	}
+
+	// Get volume information for both source and destination volumes
+	var srcVolID, dstVolID uint32
+	err := windows.GetVolumeInformation(windows.StringToUTF16Ptr(srcVolume), nil, 0, &srcVolID, nil, nil, nil, 0)
+	if err != nil {
+		return false, fmt.Errorf("failed to get source volume information: %w", err)
+	}
+
+	err = windows.GetVolumeInformation(windows.StringToUTF16Ptr(dstVolume), nil, 0, &dstVolID, nil, nil, nil, 0)
+	if err != nil {
+		return false, fmt.Errorf("failed to get destination volume information: %w", err)
+	}
+
+	// Compare the volume IDs to determine if they are on the same partition
+	samePartition := srcVolID == dstVolID
+
+	slog.Debug("check src/dst volume info",
+		"samePartition", samePartition,
+		"src volume", srcVolID,
+		"dst volume", dstVolID)
+
+	return samePartition, nil
+}

--- a/internal/cli/partition_windows.go
+++ b/internal/cli/partition_windows.go
@@ -5,7 +5,6 @@ package cli
 import (
 	"fmt"
 	"log/slog"
-	"os"
 	"path/filepath"
 
 	"golang.org/x/sys/windows"

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -112,7 +112,7 @@ type parser struct{}
 
 func validSize(fl validator.FieldLevel) bool {
 	value := strings.ToUpper(fl.Field().String())
-	re := regexp.MustCompile(`^\d+(KB|MB|GB|TB|PB)$`)
+	re := regexp.MustCompile(`^\d+(KB|MB|GB|TB|PB)|$`) // empty is acceptable
 	return re.MatchString(value)
 }
 


### PR DESCRIPTION
## What
This PR refactors the file moving logic to use the `move` function, which checks if the source and destination reside on the same partition before deciding whether to perform a simple `os.Rename()` or fall back to a `copy-and-delete` approach. The `move` function handles the logic of ensuring the destination directory exists and correctly handles partition checks, providing a more robust and flexible solution for moving files across different filesystems.

## Why

The `os.Rename` function is designed for file moves within the same file system. When attempting to move files across different partitions or mount points, it results in an "invalid cross-device link" error. To address this, I’ve added a fallback mechanism that uses a copy-and-delete approach when the source and destination are on different partitions. This ensures that files can still be "moved" by copying them to the new location and deleting the original, effectively simulating a move even across different file systems

fix #38 