### PR TITLE
Make trash dir configuable instead of being hardcoded to ~/.gomi

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,9 +121,12 @@ Here is an example of the default config:
 
 ```yaml
 core:
+  trash_dir: ~/.gomi  # Path to store trashed files. Can be changed to another location.
+                      # Supports environment variable expansion like $HOME or ~.
+                      # If empty, defaults to ~/.gomi.
   restore:
-    confirm: false  # If true, prompts for confirmation before restoring (yes/no)
-    verbose: true   # If true, displays detailed restoration information
+    confirm: false    # If true, prompts for confirmation before restoring (yes/no)
+    verbose: true     # If true, displays detailed restoration information
 
 ui:
   density: spacious # or compact

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -110,7 +110,7 @@ func Run(v Version) error {
 		version: v,
 		option:  opt,
 		config:  cfg,
-		history: history.New(cfg.Core.TrashHome, cfg.History),
+		history: history.New(cfg.Core.TrashDir, cfg.History),
 		runID:   runID(),
 	}
 

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -110,7 +110,7 @@ func Run(v Version) error {
 		version: v,
 		option:  opt,
 		config:  cfg,
-		history: history.New(cfg.History),
+		history: history.New(cfg.Core.TrashHome, cfg.History),
 		runID:   runID(),
 	}
 
@@ -266,7 +266,7 @@ func (c CLI) Put(args []string) error {
 			if os.IsNotExist(err) {
 				return fmt.Errorf("%s: no such file or directory", arg)
 			}
-			file, err := history.FileInfo(c.runID, arg)
+			file, err := c.history.FileInfo(c.runID, arg)
 			if err != nil {
 				return err
 			}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -26,8 +26,8 @@ type Config struct {
 }
 
 type Core struct {
-	TrashHome string  `yaml:"trash_home" validate:"dirpath|allowEmpty"`
-	Restore   Restore `yaml:"restore"`
+	TrashDir string  `yaml:"trash_dir" validate:"dirpath|allowEmpty"`
+	Restore  Restore `yaml:"restore"`
 }
 
 type UI struct {
@@ -126,7 +126,7 @@ func allowEmpty(fl validator.FieldLevel) bool {
 func (p parser) getDefaultConfig() Config {
 	return Config{
 		Core: Core{
-			TrashHome: filepath.Join(os.Getenv("HOME"), ".gomi"),
+			TrashDir: filepath.Join(os.Getenv("HOME"), ".gomi"),
 			Restore: Restore{
 				Verbose: true,
 				Confirm: true,
@@ -350,11 +350,11 @@ func Parse(path string) (Config, error) {
 	}
 
 	// expand tilda etc
-	trashHome, err := shell.ExpandHome(cfg.Core.TrashHome)
+	trashDir, err := shell.ExpandHome(cfg.Core.TrashDir)
 	if err != nil {
 		return cfg, parsingError{err: err}
 	}
-	cfg.Core.TrashHome = trashHome
+	cfg.Core.TrashDir = trashDir
 
 	return cfg, nil
 }

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/MakeNowJust/heredoc/v2"
 	"github.com/babarot/gomi/internal/env"
+	"github.com/babarot/gomi/internal/shell"
 	"github.com/go-playground/validator/v10"
 	"github.com/muesli/reflow/indent"
 	"gopkg.in/yaml.v2"
@@ -25,7 +26,8 @@ type Config struct {
 }
 
 type Core struct {
-	Restore Restore `yaml:"restore"`
+	TrashHome string  `yaml:"trash_home" validate:"dirpath|allowEmpty"`
+	Restore   Restore `yaml:"restore"`
 }
 
 type UI struct {
@@ -58,8 +60,8 @@ type excludeConfig struct {
 }
 
 type size struct {
-	Min string `yaml:"min" validate:"validSize"`
-	Max string `yaml:"max" validate:"validSize"`
+	Min string `yaml:"min" validate:"validSize|allowEmpty"`
+	Max string `yaml:"max" validate:"validSize|allowEmpty"`
 }
 
 type previewConfig struct {
@@ -112,13 +114,19 @@ type parser struct{}
 
 func validSize(fl validator.FieldLevel) bool {
 	value := strings.ToUpper(fl.Field().String())
-	re := regexp.MustCompile(`^\d+(KB|MB|GB|TB|PB)|$`) // empty is acceptable
+	re := regexp.MustCompile(`^\d+(KB|MB|GB|TB|PB)$`)
 	return re.MatchString(value)
+}
+
+func allowEmpty(fl validator.FieldLevel) bool {
+	str := fl.Field().String()
+	return strings.TrimSpace(str) == "" || fl.Parent().FieldByName(fl.StructFieldName()).IsValid()
 }
 
 func (p parser) getDefaultConfig() Config {
 	return Config{
 		Core: Core{
+			TrashHome: filepath.Join(os.Getenv("HOME"), ".gomi"),
 			Restore: Restore{
 				Verbose: true,
 				Confirm: true,
@@ -314,6 +322,7 @@ func initParser() parser {
 	})
 
 	_ = validate.RegisterValidation("validSize", validSize)
+	_ = validate.RegisterValidation("allowEmpty", allowEmpty)
 
 	return parser{}
 }
@@ -339,6 +348,13 @@ func Parse(path string) (Config, error) {
 	if err != nil {
 		return cfg, parsingError{err: err}
 	}
+
+	// expand tilda etc
+	trashHome, err := shell.ExpandHome(cfg.Core.TrashHome)
+	if err != nil {
+		return cfg, parsingError{err: err}
+	}
+	cfg.Core.TrashHome = trashHome
 
 	return cfg, nil
 }

--- a/internal/history/migration.go
+++ b/internal/history/migration.go
@@ -10,8 +10,11 @@ const oldHistoryFile = "inventory.json"
 
 // init is called when the application starts, to handle migration from inventory.json to history.json
 func init() {
-	oldPath := filepath.Join(gomiPath, oldHistoryFile)
-	newPath := filepath.Join(gomiPath, historyFile)
+	// Before v1.2.2, the trash home was fixed, so these are hardcoded in the migration script.
+	fixedHome := filepath.Join(os.Getenv("HOME"), ".gomi")
+
+	oldPath := filepath.Join(fixedHome, oldHistoryFile)
+	newPath := filepath.Join(fixedHome, historyFile)
 
 	// Check if inventory.json exists and rename it to history.json
 	if _, err := os.Stat(oldPath); err == nil {

--- a/internal/shell/shell.go
+++ b/internal/shell/shell.go
@@ -1,0 +1,100 @@
+package shell
+
+import (
+	"bytes"
+	"errors"
+	"fmt"
+	"log/slog"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+func RunCommand(input string) (string, int, error) {
+	cmd := exec.Command("bash", "-c", input)
+	var stdout, stderr bytes.Buffer
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+	err := cmd.Run()
+	output := stdout.String()
+	if errStr := stderr.String(); errStr != "" {
+		output = errStr
+		slog.Warn("command might be failed",
+			"command", input,
+			"output", output,
+		)
+	}
+	if err == nil {
+		return output, 0, nil
+	}
+	var ee *exec.ExitError
+	if !errors.As(err, &ee) {
+		return output, -1, err
+	}
+	return output, ee.ExitCode(), nil
+}
+
+func ExpandHome(input string) (string, error) {
+	result := input
+
+	// 1. expand tilda
+	if strings.HasPrefix(result, "~/") {
+		home := os.Getenv("HOME")
+		if home == "" {
+			return "", fmt.Errorf("HOME environment variable is not set")
+		}
+		result = strings.Replace(result, "~/", home+"/", 1)
+	} else if result == "~" {
+		home := os.Getenv("HOME")
+		if home == "" {
+			return "", fmt.Errorf("HOME environment variable is not set")
+		}
+		result = home
+	}
+
+	// 2. expand env, e.g. $HOME、${HOME}
+	for {
+		start := strings.Index(result, "$")
+		if start == -1 {
+			break
+		}
+
+		var end int
+		var varName string
+
+		if strings.HasPrefix(result[start:], "${") {
+			// case of ${VAR} format
+			end = strings.Index(result[start:], "}")
+			if end == -1 {
+				return "", fmt.Errorf("unclosed variable brace in input: %s", input)
+			}
+			end += start
+			varName = result[start+2 : end]
+			end++ // go to next of "}"
+		} else {
+			for i := start + 1; i < len(result); i++ {
+				if !isShellVarChar(result[i]) {
+					end = i
+					break
+				}
+			}
+			if end == 0 {
+				end = len(result)
+			}
+			varName = result[start+1 : end]
+		}
+
+		value := os.Getenv(varName)
+		if value == "" {
+			value = ""
+		}
+
+		result = result[:start] + value + result[end:]
+	}
+
+	return result, nil
+}
+
+func isShellVarChar(c byte) bool {
+	return (c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z') || (c >= '0' && c <= '9') || c == '_'
+}

--- a/internal/ui/file.go
+++ b/internal/ui/file.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 
 	"github.com/babarot/gomi/internal/history"
+	"github.com/babarot/gomi/internal/shell"
 	"github.com/babarot/gomi/internal/utils"
 
 	"github.com/alecthomas/chroma"
@@ -102,7 +103,7 @@ func (f File) Browse() (string, error) {
 			}
 			return strings.Join(lines, "\n"), nil
 		}
-		out, _, err := utils.RunShell(input)
+		out, _, err := shell.RunCommand(input)
 		if err != nil {
 			slog.Error("command failed", "command", input, "error", err)
 		}

--- a/internal/utils/utils.go
+++ b/internal/utils/utils.go
@@ -1,11 +1,7 @@
 package utils
 
 import (
-	"bytes"
-	"errors"
-	"log/slog"
 	"os"
-	"os/exec"
 	"path/filepath"
 	"sync"
 )
@@ -51,28 +47,4 @@ func DirSize(path string) (int64, error) {
 	}
 
 	return size, nil
-}
-
-func RunShell(input string) (string, int, error) {
-	cmd := exec.Command("bash", "-c", input)
-	var stdout, stderr bytes.Buffer
-	cmd.Stdout = &stdout
-	cmd.Stderr = &stderr
-	err := cmd.Run()
-	output := stdout.String()
-	if errStr := stderr.String(); errStr != "" {
-		output = errStr
-		slog.Warn("command might be failed",
-			"command", input,
-			"output", output,
-		)
-	}
-	if err == nil {
-		return output, 0, nil
-	}
-	var ee *exec.ExitError
-	if !errors.As(err, &ee) {
-		return output, -1, err
-	}
-	return output, ee.ExitCode(), nil
 }


### PR DESCRIPTION
## WHAT


- Made `TrashDir` configurable instead of being hardcoded to `~/.gomi`
  - Added `trash_dir` setting in `config.yaml`
  - Allowed environment variable expansion (`~`, `$HOME`, etc.) for `trash_dir`
  - Updated the `history` package to respect `TrashDir`
  - Kept the hardcoded path for versions before `v1.2.2` in the migration script
  - Added `allowEmpty` validation to allow empty values for `trash_dir` and similar fields
- Moved shell command execution utility from `utils` to a new `shell` package and renamed `RunShell` to `RunCommand`

## WHY

fix #55 
