### PR TITLE
Escape string to being passed to cd

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/babarot/gomi
 go 1.23
 
 require (
+	al.essio.dev/pkg/shellescape v1.5.1
 	github.com/MakeNowJust/heredoc/v2 v2.0.1
 	github.com/alecthomas/chroma v0.10.0
 	github.com/charmbracelet/bubbles v0.20.0

--- a/go.sum
+++ b/go.sum
@@ -1,3 +1,5 @@
+al.essio.dev/pkg/shellescape v1.5.1 h1:86HrALUujYS/h+GtqoB26SBEdkWfmMI6FubjXlsXyho=
+al.essio.dev/pkg/shellescape v1.5.1/go.mod h1:6sIqp7X2P6mThCQ7twERpZTuigpr6KbZWtls1U8I890=
 github.com/MakeNowJust/heredoc/v2 v2.0.1 h1:rlCHh70XXXv7toz95ajQWOWQnN4WNLt0TdpZYIR/J6A=
 github.com/MakeNowJust/heredoc/v2 v2.0.1/go.mod h1:6/2Abh5s+hc3g9nbWLe9ObDIOhaRrqsyY9MWy+4JdRM=
 github.com/alecthomas/chroma v0.10.0 h1:7XDcGkCQopCNKjZHfYrNLraA+M7e0fMiJ/Mfikbfjek=
@@ -51,6 +53,8 @@ github.com/go-playground/validator/v10 v10.24.0 h1:KHQckvo8G6hlWnrPX4NJJ+aBfWNAE
 github.com/go-playground/validator/v10 v10.24.0/go.mod h1:GGzBIJMuE98Ic/kJsBXbz1x/7cByt++cQ+YOuDM5wus=
 github.com/gobwas/glob v0.2.3 h1:A4xDbljILXROh+kObIiy5kIaPYD8e96x1tgBhUI5J+Y=
 github.com/gobwas/glob v0.2.3/go.mod h1:d3Ez4x06l9bZtSvzIay5+Yzi0fmZzPgnTbPcKjJAkT8=
+github.com/google/shlex v0.0.0-20191202100458-e7afc7fbc510 h1:El6M4kTTCOh6aBiKaUGG7oYTSPP8MxqL4YI3kZKwcP4=
+github.com/google/shlex v0.0.0-20191202100458-e7afc7fbc510/go.mod h1:pupxD2MaaD3pAXIBCelhxNneeOaAeabZDe5s4K6zSpQ=
 github.com/jessevdk/go-flags v1.6.1 h1:Cvu5U8UGrLay1rZfv/zP7iLpSHGUZ/Ou68T0iX1bBK4=
 github.com/jessevdk/go-flags v1.6.1/go.mod h1:Mk8T1hIAWpOiJiHa9rJASDK2UGWji0EuPGBnNLMooyc=
 github.com/jimschubert/answer v0.1.5 h1:IqmyPIe+KBhqHodF0pCo+V/zzcKuugMh8khtH6Rz/LE=

--- a/internal/ui/file.go
+++ b/internal/ui/file.go
@@ -13,6 +13,7 @@ import (
 	"github.com/babarot/gomi/internal/shell"
 	"github.com/babarot/gomi/internal/utils"
 
+	"al.essio.dev/pkg/shellescape"
 	"github.com/alecthomas/chroma"
 	"github.com/alecthomas/chroma/lexers"
 	"github.com/alecthomas/chroma/quick"
@@ -82,7 +83,7 @@ func (f File) Browse() (string, error) {
 		return content, errCannotPreview
 	}
 	if fi.IsDir() {
-		input := fmt.Sprintf("cd %s; %s", f.To, f.dirListCommand)
+		input := fmt.Sprintf("cd %s; %s", shellescape.Quote(f.To), f.dirListCommand)
 		if input == "" {
 			slog.Debug("preview dir command is not set, fallback to builtin dir func")
 			lines := []string{}
@@ -103,6 +104,7 @@ func (f File) Browse() (string, error) {
 			}
 			return strings.Join(lines, "\n"), nil
 		}
+		slog.Debug("command to list dir", "input", input)
 		out, _, err := shell.RunCommand(input)
 		if err != nil {
 			slog.Error("command failed", "command", input, "error", err)


### PR DESCRIPTION
## WHAT


as per title

before

```
8:53PM DEBU <ui/file.go:107> command to list dir input="cd /Users/babarot/.gomi/2025/02/10/cukub55eq52ut1nn5j3g/alice and bob.cukub55eq52ut1nn5j40; exa -T --color=always --icons"
8:53PM WARN <shell/shell.go:22> command might be failed command="cd /Users/babarot/.gomi/2025/02/10/cukub55eq52ut1nn5j3g/alice and bob.cukub55eq52ut1nn5j40; exa -T --color=always --icons"
  output=
  │ bash: line 1: cd: too many arguments
```

after

```
8:53PM DEBU <ui/file.go:107> command to list dir input="cd '/Users/babarot/.gomi/2025/02/10/cukub55eq52ut1nn5j3g/alice and bob.cukub55eq52ut1nn5j40'; exa -T --color=always --icons"
```


## WHY

fix #58 