### PR TITLE
Add windows wildcard support

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -27,8 +27,8 @@ type Core struct {
 	// Trash contains trash management configuration
 	Trash TrashConfig `yaml:"trash"`
 
-	// TODO: HomeFallback enables fallback to home trash when external trash fails
-	// HomeFallback bool `yaml:"home_fallback"`
+	// HomeFallback enables fallback to home trash when external trash fails
+	HomeFallback bool `yaml:"home_fallback"`
 
 	// Restore contains restore-specific settings
 	Restore RestoreConfig `yaml:"restore"`
@@ -46,7 +46,7 @@ type TrashConfig struct {
 	Strategy string `yaml:"strategy" validate:"validStrategy|allowEmpty"`
 
 	// GomiDir specifies the trash directory for legacy mode
-	GomiDir string `yaml:"gomi_dir" validate:"dirpath|allowEmpty"`
+	GomiDir string `yaml:"gomi_dir" validate:"omitempty,validDirPath"`
 }
 
 // RestoreConfig defines settings for file restoration behavior
@@ -278,6 +278,7 @@ func (c *Config) validate() error {
 	_ = validate.RegisterValidation("validSize", validateSize)
 	_ = validate.RegisterValidation("validColorCode", validateColorCode)
 	_ = validate.RegisterValidation("deprecated", validateDeprecated)
+	_ = validate.RegisterValidation("validDirPath", validateDirPath)
 
 	if err := validate.Struct(c); err != nil {
 		if validationErrors, ok := err.(validator.ValidationErrors); ok {

--- a/internal/config/defaults.go
+++ b/internal/config/defaults.go
@@ -16,7 +16,7 @@ func NewDefaultConfig() *Config {
 				Strategy: "auto",
 				GomiDir:  filepath.Join(homedir, ".gomi"),
 			},
-			// TODO: HomeFallback: true,
+			HomeFallback: true,
 			Restore: RestoreConfig{
 				Confirm: true,
 				Verbose: true,


### PR DESCRIPTION
## WHAT

Add Windows wildcard support and home fallback feature

- Add glob pattern expansion for Windows file paths
- Enable home fallback option when external trash fails
- Fix directory path validation to better handle Windows paths

## WHY

fix #63 