### PR TITLE
Add toggle between trash and original path display in detail view

### DIFF
--- a/internal/ui/keys/detail.go
+++ b/internal/ui/keys/detail.go
@@ -81,12 +81,12 @@ var DetailKeys = &DetailKeyMap{
 	),
 	AtSign: key.NewBinding(
 		key.WithKeys("@"),
-		key.WithHelp("@", "datefmt"),
+		key.WithHelp("@", "info"),
 	),
-	GotoTop:      key.NewBinding(key.WithKeys("g"), key.WithHelp("g", "go to start")),
-	GotoBottom:   key.NewBinding(key.WithKeys("G"), key.WithHelp("G", "go to end")),
-	HalfPageUp:   key.NewBinding(key.WithKeys("u"), key.WithHelp("u", "½ page up")),
-	HalfPageDown: key.NewBinding(key.WithKeys("d"), key.WithHelp("d", "½ page down")),
+	GotoTop:      key.NewBinding(key.WithKeys("g"), key.WithHelp("g", "jump to top")),
+	GotoBottom:   key.NewBinding(key.WithKeys("G"), key.WithHelp("G", "jump to bottom")),
+	HalfPageUp:   key.NewBinding(key.WithKeys("u"), key.WithHelp("u", "half page up")),
+	HalfPageDown: key.NewBinding(key.WithKeys("d"), key.WithHelp("d", "half page down")),
 }
 
 var PreviewKeys = viewport.KeyMap{

--- a/internal/ui/keys/list.go
+++ b/internal/ui/keys/list.go
@@ -48,6 +48,6 @@ var ListKeys = &ListKeyMap{
 	),
 	Space: key.NewBinding(
 		key.WithKeys(" "),
-		key.WithHelp("space", "info"),
+		key.WithHelp("space", "detail"),
 	),
 }

--- a/internal/ui/renderer.go
+++ b/internal/ui/renderer.go
@@ -69,6 +69,11 @@ func (m Model) renderFooter() string {
 func (m Model) renderDeletedFrom() string {
 	file := m.detailFile
 	text := filepath.Dir(file.OriginalPath)
+	title := "Deleted From"
+	if !m.locationOrigin {
+		title = "Trash Path"
+		text = filepath.Dir(file.TrashPath)
+	}
 	w := wordwrap.NewWriter(46)
 	w.Breakpoints = []rune{'/', '.'}
 	w.KeepNewlines = false
@@ -77,7 +82,7 @@ func (m Model) renderDeletedFrom() string {
 	return styles.DeletedFromSection(m.config).Render(
 		lipgloss.JoinVertical(
 			lipgloss.Left,
-			styles.DeletedFromTitle(m.config).MarginBottom(1).Render("Deleted From"),
+			styles.DeletedFromTitle(m.config).MarginBottom(1).Render(title),
 			lipgloss.NewStyle().Render(w.String())),
 	)
 }

--- a/internal/ui/ui.go
+++ b/internal/ui/ui.go
@@ -83,10 +83,11 @@ type Model struct {
 	listKeys   *keys.ListKeyMap
 	detailKeys *keys.DetailKeyMap
 
-	viewType      ViewType
-	detailFile    File
-	datefmt       string
-	cannotPreview bool
+	viewType       ViewType
+	detailFile     File
+	datefmt        string
+	cannotPreview  bool
+	locationOrigin bool
 
 	files   []File
 	config  config.UI
@@ -184,6 +185,7 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 				case datefmtAbs:
 					m.datefmt = datefmtRel
 				}
+				m.locationOrigin = !m.locationOrigin
 			}
 
 		case key.Matches(
@@ -245,6 +247,9 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 					}
 				}
 			case DETAIL_VIEW:
+				// TODO: create another cmd (e.g. show list cmd)
+				m.locationOrigin = true
+				m.datefmt = datefmtRel
 				m.viewType = LIST_VIEW
 			}
 
@@ -389,15 +394,16 @@ func RenderList(filteredFiles []*trash.File, cfg config.UI) ([]*trash.File, erro
 	l.SetShowTitle(false)
 
 	m := Model{
-		listKeys:   keys.ListKeys,
-		detailKeys: keys.DetailKeys,
-		viewType:   LIST_VIEW,
-		datefmt:    datefmtRel,
-		files:      files,
-		config:     cfg,
-		list:       l,
-		viewport:   viewport.Model{},
-		help:       help.New(),
+		listKeys:       keys.ListKeys,
+		detailKeys:     keys.DetailKeys,
+		viewType:       LIST_VIEW,
+		datefmt:        datefmtRel,
+		locationOrigin: true,
+		files:          files,
+		config:         cfg,
+		list:           l,
+		viewport:       viewport.Model{},
+		help:           help.New(),
 	}
 
 	returnModel, err := tea.NewProgram(m).Run()


### PR DESCRIPTION
## WHAT


Improve UI/UX and key binding descriptions

- Update help text for navigation keys (g, G, u, d) to be more consistent
- Add toggle between "Deleted From" and "Trash Path" view in detail screen
- Change space key description from "info" to "detail"
- Change @ key description from "datefmt" to "info"

## WHY

This change was added to improve user experience by:

1. Making it easier for users to understand both the original and current locations of deleted files:
    - Before: Users could only see where the file was deleted from
    - After: Users can toggle between the original location ("Deleted From") and where it's currently stored ("Trash Path")
2. Addressing a likely user need:
    - When restoring files, users might want to verify both:
        - Where the file originally came from
        - Where it's currently stored in the trash
    - This is especially useful for troubleshooting or when managing multiple trash locations

The toggle feature (using the @ key) provides a simple way to access both pieces of information without cluttering the interface.
