### PR TITLE
Add Permanent Deletion Feature with Confirmation Dialog  

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,6 +156,9 @@ core:
     confirm: false     # If true, prompts for confirmation before restoring (yes/no)
     verbose: true      # If true, displays detailed restoration information
 
+  delete:
+    disable: false     # Disable permanent deletion feature
+
 ui:
   density: spacious # or compact
   preview:
@@ -184,6 +187,7 @@ ui:
         scroll:
           fg: "#EEEEDD"
           bg: "#3C3C3C"
+    deletion_dialog: "#FF007F" # pink
   exit_message: bye!   # Customizable exit message
   paginator_type: dots # or arabic
 

--- a/go.mod
+++ b/go.mod
@@ -54,7 +54,7 @@ require (
 	github.com/rivo/uniseg v0.4.7 // indirect
 	github.com/sahilm/fuzzy v0.1.1 // indirect
 	golang.org/x/crypto v0.32.0 // indirect
-	golang.org/x/exp v0.0.0-20231006140011-7918f672742d // indirect
+	golang.org/x/exp v0.0.0-20240909161429-701f63a606c0 // indirect
 	golang.org/x/net v0.34.0 // indirect
 	golang.org/x/sys v0.30.0 // indirect
 	golang.org/x/text v0.21.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -117,8 +117,8 @@ github.com/stretchr/testify v1.10.0 h1:Xv5erBjTwe/5IxqUQTdXv5kgmIvbHo3QQyRwhJsOf
 github.com/stretchr/testify v1.10.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
 golang.org/x/crypto v0.32.0 h1:euUpcYgM8WcP71gNpTqQCn6rC2t6ULUPiOzfWaXVVfc=
 golang.org/x/crypto v0.32.0/go.mod h1:ZnnJkOaASj8g0AjIduWNlq2NRxL0PlBrbKVyZ6V/Ugc=
-golang.org/x/exp v0.0.0-20231006140011-7918f672742d h1:jtJma62tbqLibJ5sFQz8bKtEM8rJBtfilJ2qTU199MI=
-golang.org/x/exp v0.0.0-20231006140011-7918f672742d/go.mod h1:ldy0pHrwJyGW56pPQzzkH36rKxoZW1tw7ZJpeKx+hdo=
+golang.org/x/exp v0.0.0-20240909161429-701f63a606c0 h1:e66Fs6Z+fZTbFBAxKfP3PALWBtpfqks2bwGcexMxgtk=
+golang.org/x/exp v0.0.0-20240909161429-701f63a606c0/go.mod h1:2TbTHSBQa924w8M6Xs1QcRcFwyucIwBGpK1p2f1YFFY=
 golang.org/x/net v0.34.0 h1:Mb7Mrk043xzHgnRM88suvJFwzVrRfHEHJEl5/71CKw0=
 golang.org/x/net v0.34.0/go.mod h1:di0qlW3YNM5oh6GqDGQr92MyTozJPmybPK4Ev/Gm31k=
 golang.org/x/sync v0.11.0 h1:GGz8+XQP4FvTTrjZPzNKTMFtSXH80RAzG+5ghFPgK9w=

--- a/internal/cli/restore.go
+++ b/internal/cli/restore.go
@@ -35,7 +35,7 @@ func (c *CLI) Restore() error {
 	}
 
 	// Show UI for file selection
-	selected, err := ui.RenderList(filtered, c.config.UI)
+	selected, err := ui.RenderList(c.manager, filtered, c.config.UI)
 	if err != nil {
 		return fmt.Errorf("failed to show file selection UI: %w", err)
 	}

--- a/internal/cli/restore.go
+++ b/internal/cli/restore.go
@@ -35,7 +35,7 @@ func (c *CLI) Restore() error {
 	}
 
 	// Show UI for file selection
-	selected, err := ui.RenderList(c.manager, filtered, c.config.UI)
+	selected, err := ui.RenderList(c.manager, filtered, c.config)
 	if err != nil {
 		return fmt.Errorf("failed to show file selection UI: %w", err)
 	}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -32,6 +32,7 @@ type Core struct {
 
 	// Restore contains restore-specific settings
 	Restore RestoreConfig `yaml:"restore"`
+	Delete  DeleteConfig  `yaml:"delete"`
 
 	// Deprecated
 	TrashDir string `yaml:"trash_dir" validate:"deprecated"`
@@ -56,6 +57,11 @@ type RestoreConfig struct {
 
 	// Verbose enables detailed output during restore
 	Verbose bool `yaml:"verbose"`
+}
+
+// DeleteConfig defines settings for file permanent deletion behavior
+type DeleteConfig struct {
+	Disable bool `yaml:"disable"`
 }
 
 // UI holds all user interface related configurations

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -78,8 +78,9 @@ type UI struct {
 
 // StyleConfig defines the visual styling of the UI
 type StyleConfig struct {
-	ListView   ListViewConfig   `yaml:"list_view"`
-	DetailView DetailViewConfig `yaml:"detail_view"`
+	ListView       ListViewConfig   `yaml:"list_view"`
+	DetailView     DetailViewConfig `yaml:"detail_view"`
+	DeletionDialog string           `yaml:"deletion_dialog" validate:"validColorCode|allowEmpty"`
 }
 
 // ListViewConfig configures the file list view
@@ -196,6 +197,9 @@ func Load(path string) (*Config, error) {
 		return nil, err
 	}
 
+	// Set default value if empty
+	cfg.setDefault()
+
 	slog.Debug("config successfully loaded")
 	return cfg, nil
 }
@@ -305,4 +309,12 @@ func (c *Config) expandPaths() error {
 	}
 
 	return nil
+}
+
+func (c *Config) setDefault() {
+	// Set color for deletion confirmation dialog
+	// Since deletion is a potentially destructive operation, use a distinctive color to emphasize caution
+	if c.UI.Style.DeletionDialog == "" {
+		c.UI.Style.DeletionDialog = "205"
+	}
 }

--- a/internal/config/defaults.go
+++ b/internal/config/defaults.go
@@ -60,6 +60,7 @@ func NewDefaultConfig() *Config {
 						},
 					},
 				},
+				DeletionDialog: "#FF007F",
 			},
 		},
 		History: History{

--- a/internal/config/defaults.go
+++ b/internal/config/defaults.go
@@ -21,6 +21,9 @@ func NewDefaultConfig() *Config {
 				Confirm: true,
 				Verbose: true,
 			},
+			Delete: DeleteConfig{
+				Disable: false,
+			},
 		},
 		UI: UI{
 			Density: "spacious",

--- a/internal/ui/keys/detail.go
+++ b/internal/ui/keys/detail.go
@@ -12,6 +12,7 @@ type DetailKeyMap struct {
 	Esc    key.Binding
 	Quit   key.Binding
 	AtSign key.Binding
+	Delete key.Binding
 
 	// Preview
 	GotoTop      key.Binding
@@ -23,6 +24,8 @@ type DetailKeyMap struct {
 
 	Help      key.Binding
 	HelpClose key.Binding
+
+	showDelete bool
 }
 
 func (k DetailKeyMap) ShortHelp() []key.Binding {
@@ -35,8 +38,14 @@ func (k DetailKeyMap) ShortHelp() []key.Binding {
 }
 
 func (k DetailKeyMap) FullHelp() [][]key.Binding {
+	first := []key.Binding{
+		k.Next, k.Prev, k.Space, k.Esc, k.AtSign,
+	}
+	if k.showDelete {
+		first = append(first, k.Delete)
+	}
 	return [][]key.Binding{
-		{k.Next, k.Prev, k.Space, k.Esc, k.AtSign},
+		first,
 		{k.PreviewUp, k.PreviewDown, k.HalfPageUp, k.HalfPageDown, k.GotoTop, k.GotoBottom},
 		{k.HelpClose, k.Quit},
 	}
@@ -94,4 +103,12 @@ var PreviewKeys = viewport.KeyMap{
 	Down:         key.NewBinding(key.WithKeys("j", "down")),
 	HalfPageUp:   key.NewBinding(key.WithKeys("u")),
 	HalfPageDown: key.NewBinding(key.WithKeys("d")),
+}
+
+func (k *DetailKeyMap) AddDeleteKey() {
+	k.showDelete = true
+	k.Delete = key.NewBinding(
+		key.WithKeys("D"),
+		key.WithHelp("D", "delete"),
+	)
 }

--- a/internal/ui/keys/list.go
+++ b/internal/ui/keys/list.go
@@ -3,13 +3,13 @@ package keys
 import "github.com/charmbracelet/bubbles/key"
 
 type ListKeyMap struct {
-	Quit      key.Binding
-	Enter     key.Binding
-	Space     key.Binding
-	Select    key.Binding
-	DeSelect  key.Binding
-	Delete    key.Binding
-	DeleteYes key.Binding
+	Quit     key.Binding
+	Enter    key.Binding
+	Space    key.Binding
+	Select   key.Binding
+	DeSelect key.Binding
+	Delete   key.Binding
+	Esc      key.Binding
 }
 
 func (k ListKeyMap) ShortHelp() []key.Binding {
@@ -24,6 +24,7 @@ func (k ListKeyMap) FullHelp() [][]key.Binding {
 	keys := append(
 		k.ShortHelp(),
 		k.DeSelect,
+		k.Esc,
 		k.Delete,
 		k.Quit,
 	)
@@ -55,9 +56,10 @@ var ListKeys = &ListKeyMap{
 	),
 	Delete: key.NewBinding(
 		key.WithKeys("D"),
-		key.WithHelp("shift+d", "delete"),
+		key.WithHelp("D", "delete"),
 	),
-	DeleteYes: key.NewBinding(
-		key.WithKeys("y", "Y"),
+	Esc: key.NewBinding(
+		key.WithKeys("esc"),
+		key.WithHelp("esc", "reset"),
 	),
 }

--- a/internal/ui/keys/list.go
+++ b/internal/ui/keys/list.go
@@ -3,12 +3,13 @@ package keys
 import "github.com/charmbracelet/bubbles/key"
 
 type ListKeyMap struct {
-	Quit     key.Binding
-	Enter    key.Binding
-	Space    key.Binding
-	Select   key.Binding
-	DeSelect key.Binding
-	Delete   key.Binding
+	Quit      key.Binding
+	Enter     key.Binding
+	Space     key.Binding
+	Select    key.Binding
+	DeSelect  key.Binding
+	Delete    key.Binding
+	DeleteYes key.Binding
 }
 
 func (k ListKeyMap) ShortHelp() []key.Binding {
@@ -33,7 +34,7 @@ func (k ListKeyMap) FullHelp() [][]key.Binding {
 
 var ListKeys = &ListKeyMap{
 	Quit: key.NewBinding(
-		key.WithKeys("ctrl+c"),
+		key.WithKeys("ctrl+c", "q"),
 		key.WithHelp("ctrl+c", "quit"),
 	),
 	Select: key.NewBinding(
@@ -55,5 +56,8 @@ var ListKeys = &ListKeyMap{
 	Delete: key.NewBinding(
 		key.WithKeys("D"),
 		key.WithHelp("shift+d", "delete"),
+	),
+	DeleteYes: key.NewBinding(
+		key.WithKeys("y", "Y"),
 	),
 }

--- a/internal/ui/keys/list.go
+++ b/internal/ui/keys/list.go
@@ -8,6 +8,7 @@ type ListKeyMap struct {
 	Space    key.Binding
 	Select   key.Binding
 	DeSelect key.Binding
+	Delete   key.Binding
 }
 
 func (k ListKeyMap) ShortHelp() []key.Binding {
@@ -22,6 +23,7 @@ func (k ListKeyMap) FullHelp() [][]key.Binding {
 	keys := append(
 		k.ShortHelp(),
 		k.DeSelect,
+		k.Delete,
 		k.Quit,
 	)
 	return [][]key.Binding{
@@ -49,5 +51,9 @@ var ListKeys = &ListKeyMap{
 	Space: key.NewBinding(
 		key.WithKeys(" "),
 		key.WithHelp("space", "detail"),
+	),
+	Delete: key.NewBinding(
+		key.WithKeys("D"),
+		key.WithHelp("shift+d", "delete"),
 	),
 }

--- a/internal/ui/keys/list.go
+++ b/internal/ui/keys/list.go
@@ -10,6 +10,8 @@ type ListKeyMap struct {
 	DeSelect key.Binding
 	Delete   key.Binding
 	Esc      key.Binding
+
+	showDelete bool
 }
 
 func (k ListKeyMap) ShortHelp() []key.Binding {
@@ -25,9 +27,11 @@ func (k ListKeyMap) FullHelp() [][]key.Binding {
 		k.ShortHelp(),
 		k.DeSelect,
 		k.Esc,
-		k.Delete,
-		k.Quit,
 	)
+	if k.showDelete {
+		keys = append(keys, k.Delete)
+	}
+	keys = append(keys, k.Quit)
 	return [][]key.Binding{
 		keys,
 	}
@@ -54,12 +58,16 @@ var ListKeys = &ListKeyMap{
 		key.WithKeys(" "),
 		key.WithHelp("space", "detail"),
 	),
-	Delete: key.NewBinding(
-		key.WithKeys("D"),
-		key.WithHelp("D", "delete"),
-	),
 	Esc: key.NewBinding(
 		key.WithKeys("esc"),
 		key.WithHelp("esc", "reset"),
 	),
+}
+
+func (k *ListKeyMap) AddDeleteKey() {
+	k.showDelete = true
+	k.Delete = key.NewBinding(
+		key.WithKeys("D"),
+		key.WithHelp("D", "delete"),
+	)
 }

--- a/internal/ui/renderer.go
+++ b/internal/ui/renderer.go
@@ -196,8 +196,14 @@ func (m Model) formatDeleteConfirmation(target string, isSingleTarget bool) stri
 }
 
 func (m Model) renderDialogOverList(dialogContent string) string {
-	baseList := m.list.View()
-	listLines := strings.Split(baseList, "\n")
+	var baseView string
+	switch m.prevViewType {
+	case LIST_VIEW:
+		baseView = m.list.View()
+	case DETAIL_VIEW:
+		baseView = renderDetailed(m)
+	}
+	listLines := strings.Split(baseView, "\n")
 	dialogLines := strings.Split(dialogContent, "\n")
 
 	dialogStartLine := (len(listLines) - len(dialogLines)) / 2

--- a/internal/ui/renderer.go
+++ b/internal/ui/renderer.go
@@ -2,6 +2,7 @@ package ui
 
 import (
 	"fmt"
+	"log/slog"
 	"path/filepath"
 	"strings"
 	"time"
@@ -13,6 +14,7 @@ import (
 	"github.com/gabriel-vasile/mimetype"
 	"github.com/muesli/reflow/wordwrap"
 	"github.com/muesli/termenv"
+	"github.com/samber/lo"
 )
 
 func renderDetailed(m Model) string {
@@ -138,4 +140,75 @@ func (m Model) renderPreview() string {
 		content,
 		m.previewFooter(),
 	)
+}
+
+func (m Model) renderDeleteConfirmation() string {
+	dialogMaxWidth := defaultWidth - 6 // border (2) + padding (2) + buffer (2)
+	_, displayText, isSingleTarget := m.prepareDeleteTarget(dialogMaxWidth)
+	dialogContent := m.formatDeleteConfirmation(displayText, isSingleTarget)
+	return m.renderDialogOverList(dialogContent)
+}
+
+func (m Model) prepareDeleteTarget(maxWidth int) ([]File, string, bool) {
+	files := selectionManager.items
+	if len(files) == 0 {
+		// single target on cursor line
+		file := m.list.SelectedItem().(File)
+		return []File{file}, "'" + file.Title() + "'", true
+	}
+
+	// from selectionManager
+	quotedNames := strings.Join(
+		lo.Map(files, func(f File, index int) string {
+			return "'" + f.Title() + "'"
+		}),
+		", ")
+
+	isSingleTarget := len(files) == 1
+	if len(files) > 1 && len(quotedNames) > maxWidth {
+		return files, fmt.Sprintf("%d files", len(files)), true
+	}
+
+	slog.Debug("length", "len(quotedNames)", len(quotedNames), "maxWidth", maxWidth)
+	return files, quotedNames, isSingleTarget
+}
+
+func (m Model) formatDeleteConfirmation(target string, isSingleTarget bool) string {
+	var contents []string
+	if isSingleTarget {
+		contents = []string{
+			"Are you sure you want to",
+			"completely delete " + target + "?",
+			"",
+			"(y/n)",
+		}
+	} else {
+		contents = []string{
+			"Are you sure you want to completely delete ",
+			target + " ?",
+			"",
+			"(y/n)",
+		}
+	}
+	return m.styles.dialog.Render(
+		lipgloss.JoinVertical(lipgloss.Center, contents...),
+	)
+}
+
+func (m Model) renderDialogOverList(dialogContent string) string {
+	baseList := m.list.View()
+	listLines := strings.Split(baseList, "\n")
+	dialogLines := strings.Split(dialogContent, "\n")
+
+	dialogStartLine := (len(listLines) - len(dialogLines)) / 2
+
+	for i, line := range dialogLines {
+		centeredLine := lipgloss.NewStyle().
+			Width(defaultWidth).
+			Align(lipgloss.Center).
+			Render(line)
+		listLines[dialogStartLine+i] = centeredLine
+	}
+
+	return strings.Join(listLines, "\n")
 }

--- a/internal/ui/ui.go
+++ b/internal/ui/ui.go
@@ -237,6 +237,20 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 				m.viewType = LIST_VIEW
 			}
 
+		case key.Matches(msg, m.listKeys.Delete):
+			switch m.viewType {
+			case LIST_VIEW:
+				if m.list.FilterState() != list.Filtering {
+					file, ok := m.list.SelectedItem().(File)
+					if ok {
+						cmds = append(cmds, getInventoryDetails(file))
+					}
+					if err := os.Remove(file.File.TrashPath); err != nil {
+						return m, errorCmd(err)
+					}
+				}
+			}
+
 		case key.Matches(msg, m.listKeys.Space):
 			switch m.viewType {
 			case LIST_VIEW:

--- a/internal/ui/ui.go
+++ b/internal/ui/ui.go
@@ -460,7 +460,8 @@ func (m *Model) newViewportModel(file File) viewport.Model {
 	return viewportModel
 }
 
-func RenderList(manager *trash.Manager, filteredFiles []*trash.File, cfg config.UI) ([]*trash.File, error) {
+func RenderList(manager *trash.Manager, filteredFiles []*trash.File, c *config.Config) ([]*trash.File, error) {
+	cfg := c.UI
 	var items []list.Item
 	var files []File
 	for _, file := range filteredFiles {
@@ -474,6 +475,12 @@ func RenderList(manager *trash.Manager, filteredFiles []*trash.File, cfg config.
 	}
 
 	d := NewRestoreDelegate(cfg, files)
+
+	if !c.Core.Delete.Disable {
+		keys.ListKeys.AddDeleteKey()
+		keys.DetailKeys.AddDeleteKey()
+	}
+
 	d.ShortHelpFunc = keys.ListKeys.ShortHelp
 	d.FullHelpFunc = keys.ListKeys.FullHelp
 	l := list.New(items, d, defaultWidth, defaultHeight)

--- a/internal/ui/ui.go
+++ b/internal/ui/ui.go
@@ -109,12 +109,12 @@ type dialogStyles struct {
 	dialog lipgloss.Style
 }
 
-func initStyles(fg string) dialogStyles {
+func initStyles(c config.StyleConfig) dialogStyles {
 	s := dialogStyles{}
 	s.dialog = lipgloss.NewStyle().
 		Border(lipgloss.RoundedBorder()).
-		BorderForeground(lipgloss.Color(fg)).
-		Foreground(lipgloss.Color(fg)).
+		BorderForeground(lipgloss.Color(c.DeletionDialog)).
+		Foreground(lipgloss.Color(c.DeletionDialog)).
 		Bold(true).
 		Padding(1, 1).
 		BorderTop(true).
@@ -483,7 +483,7 @@ func RenderList(manager *trash.Manager, filteredFiles []*trash.File, cfg config.
 		config:         cfg,
 		list:           l,
 		viewport:       viewport.Model{},
-		styles:         initStyles(cfg.Style.DeletionDialog),
+		styles:         initStyles(cfg.Style),
 		help:           help.New(),
 	}
 


### PR DESCRIPTION

This PR introduces a **permanent deletion feature** that allows users to completely remove files from the trash. To prevent accidental deletions, a confirmation dialog has also been added.  


- **Permanent Deletion:**  
  - Users can now **permanently delete files from the trash** using the `D` key.  
  - Deleted files are completely removed and cannot be recovered.  
- **Delete Confirmation Dialog:**  
  - Before a file is permanently deleted, a confirmation prompt appears.  
  - Users must press **"Y"** to confirm or **"N"** to cancel.  
  - Default deletion dialog color is configurable in `config.go`.  
- **Key Bindings Enhancements:**  
  - **`D` key**: Triggers permanent deletion.  
  - **`Esc` key**: Resets selection.  
  - **`Q` key**: Added as an alternative to `Ctrl+C` for quitting.  
- **Code Refactoring & Improvements:**  
  - Introduced `setViewType()` for better view state management.  
  - Added `deletePermanentlyCmd()` to handle permanent deletions cleanly.  
  - Improved UI styling for confirmation dialogs.  

This update **ensures safe and deliberate file deletion**, preventing accidental removals while giving users full control over their trash management.  

<img src="https://github.com/user-attachments/assets/261a0efb-a6dc-4772-a121-716cf6ef3c30" width="650">


