### PR TITLE
Create missing log path

### DIFF
--- a/internal/utils/env/env.go
+++ b/internal/utils/env/env.go
@@ -33,8 +33,8 @@ func init() {
 		}
 		GOMI_CONFIG_PATH = filepath.Join(configDir, "gomi", "config.yaml")
 	} else {
-    GOMI_CONFIG_PATH = os.Getenv("GOMI_CONFIG_PATH")
-  }
+		GOMI_CONFIG_PATH = os.Getenv("GOMI_CONFIG_PATH")
+	}
 
 	if e := os.Getenv("GOMI_LOG_PATH"); e == "" {
 		dataDir := os.Getenv("XDG_DATA_HOME")
@@ -47,6 +47,6 @@ func init() {
 		}
 		GOMI_LOG_PATH = filepath.Join(dataDir, "gomi", "debug.log")
 	} else {
-    GOMI_LOG_PATH = os.Getenv("GOMI_LOG_PATH")
-  }
+		GOMI_LOG_PATH = os.Getenv("GOMI_LOG_PATH")
+	}
 }

--- a/internal/utils/env/env.go
+++ b/internal/utils/env/env.go
@@ -32,7 +32,9 @@ func init() {
 			configDir = filepath.Join(homeDir, defaultXDGConfigDirname)
 		}
 		GOMI_CONFIG_PATH = filepath.Join(configDir, "gomi", "config.yaml")
-	}
+	} else {
+    GOMI_CONFIG_PATH = os.Getenv("GOMI_CONFIG_PATH")
+  }
 
 	if e := os.Getenv("GOMI_LOG_PATH"); e == "" {
 		dataDir := os.Getenv("XDG_DATA_HOME")
@@ -44,5 +46,7 @@ func init() {
 			dataDir = filepath.Join(homeDir, defaultXDGDataDirname)
 		}
 		GOMI_LOG_PATH = filepath.Join(dataDir, "gomi", "debug.log")
-	}
+	} else {
+    GOMI_LOG_PATH = os.Getenv("GOMI_LOG_PATH")
+  }
 }

--- a/internal/utils/log/options.go
+++ b/internal/utils/log/options.go
@@ -1,10 +1,10 @@
 package log
 
 import (
+	"fmt"
 	"io"
 	"os"
-  "fmt"
-  "path/filepath"
+	"path/filepath"
 
 	charmlog "github.com/charmbracelet/log"
 )
@@ -63,12 +63,12 @@ func UseOutputPath(path string) Option {
 		if path == "" {
 			return os.Stderr, nil
 		}
-    // If the error location's directory does not exist, create it
-    if _, err := os.Stat(filepath.Dir(path)); os.IsNotExist(err) {
-      if err := os.MkdirAll(filepath.Dir(path), 0755); err != nil {
-        return nil, fmt.Errorf("failed to create log file's directory: %w", err)
-      }
-    }
+		// If the error location's directory does not exist, create it
+		if _, err := os.Stat(filepath.Dir(path)); os.IsNotExist(err) {
+			if err := os.MkdirAll(filepath.Dir(path), 0755); err != nil {
+				return nil, fmt.Errorf("failed to create log file's directory: %w", err)
+			}
+		}
 		return os.OpenFile(path, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0644)
 	})
 }

--- a/internal/utils/log/options.go
+++ b/internal/utils/log/options.go
@@ -3,6 +3,8 @@ package log
 import (
 	"io"
 	"os"
+  "fmt"
+  "path/filepath"
 
 	charmlog "github.com/charmbracelet/log"
 )
@@ -61,6 +63,12 @@ func UseOutputPath(path string) Option {
 		if path == "" {
 			return os.Stderr, nil
 		}
+    // If the error location's directory does not exist, create it
+    if _, err := os.Stat(filepath.Dir(path)); os.IsNotExist(err) {
+      if err := os.MkdirAll(filepath.Dir(path), 0755); err != nil {
+        return nil, fmt.Errorf("failed to create log file's directory: %w", err)
+      }
+    }
 		return os.OpenFile(path, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0644)
 	})
 }


### PR DESCRIPTION
## WHAT

Create missing logpath, and support environment variables.

## WHY

Log path not completely existing would cause failover to stderr output, and environment variables for log and config path were not used if not blank.


### Sidenote

There should probably configurable support for log verbosity, theres a pretty large volume of logging for each run flowing through the charm log right now, since most people probably wont ever look at the log, logging debug by default (warn/error instead) is probably overkill and just going to slowly eat disk.