### PR TITLE
Add `--prune` option for trash management

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ Download the latest precompiled binary from [GitHub Releases][release] and place
 
 [![Packaging status](https://repology.org/badge/vertical-allrepos/gomi.svg?columns=2)](https://repology.org/project/gomi/versions)
 
-### Using [afx](https://github.com/babarot/afx)
+#### Using [afx](https://github.com/babarot/afx)
 
 Write a YAML manifest, then run the `install` command.
 
@@ -115,20 +115,20 @@ github:
 afx install
 ```
 
-### Using [Homebrew](https://brew.sh/)
+#### Using [Homebrew](https://brew.sh/)
 
 ```bash
 brew install gomi
 ```
 
-### Using [Scoop](https://scoop.sh/)
+#### Using [Scoop](https://scoop.sh/)
 
 ```bash
 scoop bucket add babarot https://github.com/babarot/scoop-bucket
 scoop install gomi
 ```
 
-### Using [AUR](https://aur.archlinux.org/gomi.git)
+#### Using [AUR](https://aur.archlinux.org/gomi.git)
 
 You can install `gomi` using an AUR helper:
 
@@ -245,6 +245,84 @@ logging:
     max_files: 3     # Number of old log files to retain
 ```
 
+## Pruning Trash Files
+
+The `--prune` option allows you to manage your trash contents by permanently removing files based on various criteria.
+
+### Basic Usage
+
+```bash
+gomi --prune=<argument>
+```
+
+### Use Cases
+
+#### 1. Remove Orphaned Metadata Files
+
+Orphaned metadata refers to `.trashinfo` files that have lost their corresponding data files in the trash. In the XDG trash specification, each trashed file has two components:
+- The actual file data (stored in `files/`)
+- A metadata file (stored in `info/` with `.trashinfo` extension) containing information about when and where the file was deleted from
+
+When the data file is lost but the metadata file remains, it becomes "orphaned". This can happen due to:
+- Manual deletion of files from the trash
+- System crashes during trash operations
+- Disk errors or file system corruption
+
+To clean up these orphaned metadata files:
+```bash
+gomi --prune=orphans
+```
+
+This command identifies and removes orphaned `.trashinfo` files to maintain trash consistency.
+
+#### 2. Remove Files Older Than Specified Duration
+Remove files that were moved to trash before the specified duration:
+
+```bash
+gomi --prune=1y     # Remove files older than 1 year
+gomi --prune=6m     # Remove files older than 6 months
+gomi --prune=30d    # Remove files older than 30 days
+gomi --prune=1w     # Remove files older than 1 week
+```
+
+#### 3. Remove Files Within a Time Range
+Remove files that were moved to trash within a specific time range:
+
+```bash
+gomi --prune=2m,3m  # Remove files trashed between 2 and 3 months ago
+gomi --prune=0d,1d  # Remove files trashed today (0-1 day ago)
+gomi --prune=1w,2w  # Remove files trashed between 1 and 2 weeks ago
+```
+
+### Duration Format
+
+The following duration units are supported:
+- `h`, `hour`, `hours` (hours)
+- `d`, `day`, `days` (days)
+- `w`, `week`, `weeks` (weeks)
+- `m`, `month`, `months` (months)
+- `y`, `year`, `years` (years)
+
+### Additional Notes
+
+- Arguments can be specified with either commas or separate `--prune` flags:
+  ```bash
+  gomi --prune=1d,7d          # Using comma
+  gomi --prune=1d --prune=7d  # Using multiple flags (same result)
+  ```
+
+
+- When more than two durations are specified, gomi uses the shortest and longest durations as the range:
+  ```bash
+  gomi --prune=0d,1d,3d   # Treats as 0d,3d (today to 3 days ago)
+  gomi --prune=2w,3d,1m   # Treats as 3d,1m (3 days to 1 month ago)
+  ```
+
+    The order of arguments doesn't matter - gomi will always use the most recent (shortest duration) and oldest (longest duration) as the time range boundaries.
+
+- The `orphans` argument cannot be combined with duration arguments.
+- This operation permanently deletes files and cannot be undone. Double confirmation will be required before deletion.
+
 ## Debugging
 
 Gain deeper insights into `gomi`'s operations by using the `--debug` flag:
@@ -273,7 +351,6 @@ The `--debug` flag has two modes:
 > logging:
 >   enabled: true # Enable logging functionality
 > ```
-
 
 ## Related
 

--- a/go.mod
+++ b/go.mod
@@ -26,6 +26,7 @@ require (
 	github.com/muesli/reflow v0.3.0
 	github.com/muesli/termenv v0.15.2
 	github.com/nxadm/tail v1.4.11
+	github.com/olekukonko/tablewriter v0.0.5
 	github.com/otiai10/copy v1.14.1
 	github.com/rs/xid v1.6.0
 	github.com/samber/lo v1.49.1

--- a/go.sum
+++ b/go.sum
@@ -78,6 +78,7 @@ github.com/mattn/go-isatty v0.0.20 h1:xfD0iDuEKnDkl03q4limB+vH+GxLEtL/jb4xVJSWWE
 github.com/mattn/go-isatty v0.0.20/go.mod h1:W+V8PltTTMOvKvAeJH7IuucS94S2C6jfK/D7dTCTo3Y=
 github.com/mattn/go-localereader v0.0.1 h1:ygSAOl7ZXTx4RdPYinUpg6W99U8jWvWi9Ye2JC/oIi4=
 github.com/mattn/go-localereader v0.0.1/go.mod h1:8fBrzywKY7BI3czFoHkuzRoWE9C+EiG4R1k4Cjx5p88=
+github.com/mattn/go-runewidth v0.0.9/go.mod h1:H031xJmbD/WCDINGzjvQ9THkh0rPKHF+m2gUSrubnMI=
 github.com/mattn/go-runewidth v0.0.12/go.mod h1:RAqKPSqVFrSLVXbA8x7dzmKdmGzieGRCM46jaSJTDAk=
 github.com/mattn/go-runewidth v0.0.16 h1:E5ScNMtiwvlvB5paMFdw9p4kSQzbXFikJ5SQO6TULQc=
 github.com/mattn/go-runewidth v0.0.16/go.mod h1:Jdepj2loyihRzMpdS35Xk/zdY8IAYHsh153qUoGf23w=
@@ -95,6 +96,8 @@ github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e h1:fD57ERR4JtEqsWb
 github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e/go.mod h1:zD1mROLANZcx1PVRCS0qkT7pwLkGfwJo4zjcN/Tysno=
 github.com/nxadm/tail v1.4.11 h1:8feyoE3OzPrcshW5/MJ4sGESc5cqmGkGCWlco4l0bqY=
 github.com/nxadm/tail v1.4.11/go.mod h1:OTaG3NK980DZzxbRq6lEuzgU+mug70nY11sMd4JXXHc=
+github.com/olekukonko/tablewriter v0.0.5 h1:P2Ga83D34wi1o9J6Wh1mRuqd4mF/x/lgBS7N7AbDhec=
+github.com/olekukonko/tablewriter v0.0.5/go.mod h1:hPp6KlRPjbx+hW8ykQs1w3UBbZlj6HuIJcUGPhkA7kY=
 github.com/otiai10/copy v1.14.1 h1:5/7E6qsUMBaH5AnQ0sSLzzTg1oTECmcCmT6lvF45Na8=
 github.com/otiai10/copy v1.14.1/go.mod h1:oQwrEDDOci3IM8dJF0d8+jnbfPDllW6vUjNc3DoZm9I=
 github.com/otiai10/mint v1.6.3 h1:87qsV/aw1F5as1eH1zS/yqHY85ANKVMgkDrf9rcxbQs=

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"path/filepath"
 	"runtime"
+	"strings"
 	"sync"
 	"time"
 
@@ -31,8 +32,17 @@ type Option struct {
 }
 
 type MetaOption struct {
-	Version bool   `short:"V" long:"version" description:"Show version"`
-	Debug   string `long:"debug" description:"View debug logs" optional-value:"full" optional:"yes" choice:"full" choice:"live"`
+	Version bool      `short:"V" long:"version" description:"Show version"`
+	Debug   string    `long:"debug" description:"View debug logs" optional-value:"full" optional:"yes" choice:"full" choice:"live"`
+	Prune   PruneArgs `long:"prune" description:"Prunes trash by removing orphaned metadata and items older than a specified duration (e.g., 30d,orphans)"`
+}
+
+type PruneArgs []string
+
+func (s *PruneArgs) UnmarshalFlag(value string) error {
+	values := strings.Split(value, ",")
+	*s = append(*s, values...)
+	return nil
 }
 
 // RmOption provides compatibility with rm command options
@@ -125,6 +135,9 @@ func (c CLI) Run(args []string) error {
 			env.GOMI_LOG_PATH,
 			c.option.Meta.Debug == debug.LiveMode,
 		)
+
+	case len(c.option.Meta.Prune) > 0:
+		return c.Prune(c.option.Meta.Prune)
 
 	case c.option.Restore:
 		return c.Restore()

--- a/internal/cli/prune.go
+++ b/internal/cli/prune.go
@@ -171,6 +171,7 @@ func (c *CLI) permanentlyDeleteByTimeRange(durations []time.Duration) error {
 		ShowRelativeTime: true,
 		Order:            table.SortDesc,
 	})
+	fmt.Println()
 	printDeletionSummary(filesToDelete, newestAge, oldestAge, len(durations) == 1)
 
 	// First confirmation
@@ -257,9 +258,10 @@ func (c *CLI) removeOrphanedMetadata() error {
 	if !c.option.Rm.Force {
 		slog.Debug("show orphaned trashinfo", "files", orphanedFiles)
 		table.PrintFiles(orphanedFiles, table.PrintOptions{
-			ShowRelativeTime: true,
+			ShowRelativeTime: false,
 			Order:            table.SortDesc,
 		})
+		fmt.Println()
 		if !ui.Confirm(fmt.Sprintf("Are you sure you want to remove %d orphaned metadata files?", len(orphanedFiles))) {
 			fmt.Println("Operation canceled.")
 			return nil

--- a/internal/cli/prune.go
+++ b/internal/cli/prune.go
@@ -180,7 +180,7 @@ func (c *CLI) permanentlyDeleteByTimeRange(durations []time.Duration) error {
 	fmt.Println()
 	// WARNING: Files will be permanently deleted and CANNOT be recovered. Are you absolutely sure?
 	fmt.Printf("%s\n", color.New(color.FgHiRed).Sprint("WARNING: This operation is permanent and cannot be undone!"))
-	if !ui.Confirm("Do you really want to permanently delete these files?") {
+	if !ui.ConfirmYes("Do you really want to permanently delete these files?") {
 		fmt.Println("Operation canceled.")
 		return nil
 	}

--- a/internal/cli/prune.go
+++ b/internal/cli/prune.go
@@ -167,7 +167,10 @@ func (c *CLI) permanentlyDeleteByTimeRange(durations []time.Duration) error {
 		return nil
 	}
 
-	table.PrintFiles(filesToDelete, true)
+	table.PrintFiles(filesToDelete, table.PrintOptions{
+		ShowRelativeTime: true,
+		Order:            table.SortDesc,
+	})
 	printDeletionSummary(filesToDelete, newestAge, oldestAge, len(durations) == 1)
 
 	// First confirmation
@@ -253,7 +256,10 @@ func (c *CLI) removeOrphanedMetadata() error {
 	// Confirm deletion unless forced
 	if !c.option.Rm.Force {
 		slog.Debug("show orphaned trashinfo", "files", orphanedFiles)
-		table.PrintFiles(orphanedFiles, true)
+		table.PrintFiles(orphanedFiles, table.PrintOptions{
+			ShowRelativeTime: true,
+			Order:            table.SortDesc,
+		})
 		if !ui.Confirm(fmt.Sprintf("Are you sure you want to remove %d orphaned metadata files?", len(orphanedFiles))) {
 			fmt.Println("Operation canceled.")
 			return nil

--- a/internal/cli/prune.go
+++ b/internal/cli/prune.go
@@ -64,7 +64,7 @@ func (c *CLI) Prune(args []string) error {
 				}
 				durations = append(durations, duration)
 			}
-			return c.pruneDurationOverFiles(durations)
+			return c.permanentlyDeleteByAge(durations)
 		}
 	}
 
@@ -114,8 +114,8 @@ func findOrphanedMetadata(trashDir string) ([]OrphanedFile, error) {
 	return orphanedFiles, nil
 }
 
-// pruneDurationOverFiles removes files that are older than the specified durations
-func (c *CLI) pruneDurationOverFiles(durations []time.Duration) error {
+// permanentlyDeleteByAge removes files that are older than the specified durations
+func (c *CLI) permanentlyDeleteByAge(durations []time.Duration) error {
 	if len(durations) == 0 {
 		return nil
 	}
@@ -162,6 +162,7 @@ func (c *CLI) pruneDurationOverFiles(durations []time.Duration) error {
 
 	green := color.New(color.FgHiGreen).SprintfFunc()
 	white := color.New(color.FgWhite).SprintfFunc()
+	red := color.New(color.FgHiRed).SprintfFunc()
 
 	fmt.Printf("%s %s %s\n",
 		green("%-20s", "Deleted At"),
@@ -189,6 +190,14 @@ func (c *CLI) pruneDurationOverFiles(durations []time.Duration) error {
 
 	if !ui.Confirm(fmt.Sprintf("Are you sure you want to remove these %d files?", len(targetFiles))) {
 		fmt.Println("Pruning canceled.")
+		return nil
+	}
+
+	// WARNING: Files will be permanently deleted and CANNOT be recovered. Are you absolutely sure?
+	fmt.Println()
+	fmt.Printf("%s\n", red("WARNING: This operation is permanent and cannot be undone!"))
+	if !ui.Confirm("Do you really want to permanently delete these files?") {
+		fmt.Println("Operation canceled.")
 		return nil
 	}
 

--- a/internal/cli/prune.go
+++ b/internal/cli/prune.go
@@ -1,0 +1,324 @@
+package cli
+
+import (
+	"errors"
+	"fmt"
+	"log/slog"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"time"
+	"unicode"
+
+	"github.com/babarot/gomi/internal/trash/xdg"
+	"github.com/babarot/gomi/internal/ui"
+	"github.com/dustin/go-humanize"
+	"github.com/fatih/color"
+)
+
+// OrphanedFile represents an orphaned metadata file with additional details
+type OrphanedFile struct {
+	Path          string
+	Size          int64
+	DeletedAt     time.Time
+	OriginalPath  string
+	TrashInfoPath string
+}
+
+var (
+	ErrInvalidArgument = errors.New("prune requires an argument (e.g., orphans)")
+)
+
+// PruneFunc represents a function that performs a pruning operation
+type PruneFunc func() error
+
+// Prune handles the pruning of trash contents
+// It processes multiple subcommands for cleaning up the trash
+func (c *CLI) Prune(args []string) error {
+	slog.Debug("pruning trash contents started")
+	defer slog.Debug("pruning trash contents finished")
+
+	if len(args) == 0 {
+		return ErrInvalidArgument
+	}
+
+	// Collect durations separately from other prune operations
+	var durations []time.Duration
+	var pruneFuncs []PruneFunc
+
+	// First pass: collect all operations and durations
+	for _, arg := range args {
+		switch arg {
+		case "orphans":
+			pruneFuncs = append(pruneFuncs, c.pruneOrphans)
+		case "":
+			return ErrInvalidArgument
+		default:
+			duration, err := parseDuration(arg)
+			if err != nil {
+				slog.Error("failed to parse duration", "error", err)
+				return fmt.Errorf("unknown prune arguments: %s", arg)
+			}
+			slog.Debug("parse duration", "duration", duration, "arg", arg)
+			durations = append(durations, duration)
+		}
+	}
+
+	// If we have any durations, add a single function to handle all of them
+	if len(durations) > 0 {
+		pruneFuncs = append(pruneFuncs, func() error {
+			return c.pruneDurationOverFiles(durations)
+		})
+	}
+
+	// Execute collected functions
+	for _, fn := range pruneFuncs {
+		if err := fn(); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+// findOrphanedMetadata finds .trashinfo files without corresponding files
+// Returns a list of paths to orphaned .trashinfo files
+func findOrphanedMetadata(trashDir string) ([]OrphanedFile, error) {
+	infoDir := filepath.Join(trashDir, "info")
+	filesDir := filepath.Join(trashDir, "files")
+
+	var orphanedFiles []OrphanedFile
+
+	entries, err := os.ReadDir(infoDir)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read info directory: %w", err)
+	}
+
+	for _, entry := range entries {
+		// Skip non-regular files and non-.trashinfo files
+		if !entry.Type().IsRegular() || !strings.HasSuffix(entry.Name(), ".trashinfo") {
+			continue
+		}
+
+		if strings.HasPrefix(entry.Name(), "._") {
+			// exclude mac resource fork
+			slog.Debug("skipped mac resource fork of .trashinfo", "path", entry.Name())
+			continue
+		}
+
+		// Remove .trashinfo suffix to get the corresponding file name
+		fileName := strings.TrimSuffix(entry.Name(), ".trashinfo")
+		trashInfoPath := filepath.Join(infoDir, entry.Name())
+
+		// Check if corresponding file exists in files directory
+		_, err := os.Stat(filepath.Join(filesDir, fileName))
+		if os.IsNotExist(err) {
+			metadata, parseErr := parseTrashInfoFile(trashInfoPath)
+			if parseErr != nil {
+				continue
+			}
+			orphanedFiles = append(orphanedFiles, metadata)
+		}
+	}
+
+	return orphanedFiles, nil
+}
+
+// pruneDurationOverFiles removes files that are older than the specified durations
+// It processes multiple durations and logs the min/max values for debugging
+func (c *CLI) pruneDurationOverFiles(durations []time.Duration) error {
+	if len(durations) == 0 {
+		return nil
+	}
+
+	// Find min and max durations
+	minDuration := durations[0]
+	maxDuration := durations[0]
+	for _, d := range durations {
+		if d < minDuration {
+			minDuration = d
+		}
+		if d > maxDuration {
+			maxDuration = d
+		}
+	}
+
+	// Log duration ranges for debugging
+	slog.Debug("processing duration-based pruning",
+		"min_duration", minDuration.String(),
+		"max_duration", maxDuration.String(),
+		"duration_count", len(durations),
+	)
+
+	// TODO: Implement the actual pruning logic here
+	// The function should consider all specified durations when deciding what to prune
+	return nil
+}
+
+// pruneOrphans removes metadata files without corresponding trashed files
+func (c *CLI) pruneOrphans() error {
+	trashDirs, err := xdg.FindAllTrashDirectories()
+	if err != nil {
+		return fmt.Errorf("failed to get trash dirs: %w", err)
+	}
+
+	var orphanedFiles []OrphanedFile
+	for _, trashDir := range trashDirs {
+		files, err := findOrphanedMetadata(trashDir)
+		if err != nil {
+			slog.Error("failed to find orphaned metadata in trash dir", "dir", trashDir, "error", err)
+			continue
+		}
+
+		orphanedFiles = append(orphanedFiles, files...)
+	}
+
+	if len(orphanedFiles) == 0 {
+		fmt.Println("No orphaned metadata files found.")
+		return nil
+	}
+
+	printOrphanedFilesTable(orphanedFiles)
+
+	// Confirm deletion unless forced
+	if !c.option.Rm.Force {
+		if !ui.Ask(fmt.Sprintf("Are you sure you want to remove %d orphaned metadata files?", len(orphanedFiles))) {
+			fmt.Println("Pruning canceled.")
+			return nil
+		}
+	}
+
+	// Remove orphaned files
+	var failedRemovals []string
+	for _, file := range orphanedFiles {
+		if err := os.Remove(file.TrashInfoPath); err != nil {
+			slog.Error("failed to remove orphaned metadata file", "file", file.TrashInfoPath, "error", err)
+			failedRemovals = append(failedRemovals, file.TrashInfoPath)
+		}
+	}
+
+	if len(failedRemovals) > 0 {
+		fmt.Printf("Failed to remove %d files:\n", len(failedRemovals))
+		for _, file := range failedRemovals {
+			fmt.Println(file)
+		}
+		return fmt.Errorf("some orphaned metadata files could not be removed")
+	}
+
+	fmt.Printf("Successfully removed %d orphaned metadata files.\n", len(orphanedFiles))
+
+	return nil
+}
+
+// printOrphanedFilesTable prints a formatted table of orphaned files
+func printOrphanedFilesTable(files []OrphanedFile) {
+	green := color.New(color.FgHiGreen).SprintfFunc()
+	white := color.New(color.FgWhite).SprintfFunc()
+
+	// fmt.Printf("Found %d orphaned metadata files:\n\n", len(files))
+	fmt.Printf("%s %s %s\n",
+		green("%-20s", "Deleted At"),
+		green("%-10s", "Size"),
+		green("%-30s", "Path"),
+	)
+
+	for _, file := range files {
+		info, err := os.Stat(file.TrashInfoPath)
+		if err != nil {
+			continue
+		}
+
+		fmt.Printf("%s %s %s\n",
+			white("%-20s", file.DeletedAt.Format("2006-01-02 15:04:05")),
+			white("%-10s", humanize.Bytes(uint64(info.Size()))),
+			white("%-30s", file.TrashInfoPath),
+		)
+	}
+	fmt.Println()
+}
+
+// parseTrashInfoFile parses a .trashinfo file and returns an OrphanedFile
+func parseTrashInfoFile(path string) (OrphanedFile, error) {
+	content, err := os.ReadFile(path)
+	if err != nil {
+		return OrphanedFile{}, err
+	}
+
+	lines := strings.Split(string(content), "\n")
+	var deletedAt time.Time
+	var originalPath string
+
+	for _, line := range lines {
+		if strings.HasPrefix(line, "Path=") {
+			originalPath = strings.TrimPrefix(line, "Path=")
+		}
+		if strings.HasPrefix(line, "DeletionDate=") {
+			deletedAtStr := strings.TrimPrefix(line, "DeletionDate=")
+			deletedAt, err = time.Parse("2006-01-02T15:04:05", deletedAtStr)
+			if err != nil {
+				return OrphanedFile{}, err
+			}
+		}
+	}
+
+	return OrphanedFile{
+		DeletedAt:     deletedAt,
+		OriginalPath:  originalPath,
+		TrashInfoPath: path,
+	}, nil
+}
+
+var unitMap = map[string]string{
+	"d":      "d",
+	"day":    "d",
+	"days":   "d",
+	"m":      "m",
+	"month":  "m",
+	"months": "m",
+	"y":      "y",
+	"year":   "y",
+	"years":  "y",
+}
+
+func splitNumberAndUnit(input string) (string, string, error) {
+	input = strings.TrimSpace(input)
+	numPart := strings.Builder{}
+	unitPart := strings.Builder{}
+
+	for _, r := range input {
+		switch {
+		case unicode.IsDigit(r):
+			numPart.WriteRune(r)
+		case unicode.IsLetter(r):
+			unitPart.WriteRune(r)
+		default:
+			return "", "", errors.New("invalid char included")
+		}
+	}
+	return numPart.String(), unitPart.String(), nil
+}
+
+func parseDuration(input string) (time.Duration, error) {
+	numStr, unit, err := splitNumberAndUnit(strings.ToLower(input))
+	if err != nil {
+		return 0, fmt.Errorf("invalid chars in duration: %s", input)
+	}
+
+	num, err := strconv.Atoi(numStr)
+	if err != nil {
+		return 0, fmt.Errorf("invalid number in duration: %s", input)
+	}
+
+	mappedUnit, exists := unitMap[unit]
+	if !exists {
+		return 0, fmt.Errorf("unsupported duration unit: %s", unit)
+	}
+
+	unitDurations := map[string]time.Duration{
+		"d": 24 * time.Hour,
+		"m": 30 * 24 * time.Hour,
+		"y": 365 * 24 * time.Hour,
+	}
+	return time.Duration(num) * unitDurations[mappedUnit], nil
+}

--- a/internal/trash/xdg/storage.go
+++ b/internal/trash/xdg/storage.go
@@ -371,3 +371,27 @@ func (s *Storage) filter(files []*trash.File) []*trash.File {
 	slog.Debug("xdg filter items", "len(files)", len(files))
 	return trash.Filter(files, opts)
 }
+
+func FindAllTrashDirectories() ([]string, error) {
+	var trashDirs []string
+
+	s := &Storage{}
+	homeTrash, err := s.initHomeTrash()
+	if err != nil {
+		return nil, fmt.Errorf("failed to initialize home trash: %w", err)
+	}
+
+	if homeTrash != nil {
+		trashDirs = append(trashDirs, homeTrash.root)
+	}
+
+	if err := s.scanExternalTrashes(); err != nil {
+		return nil, fmt.Errorf("failed to scan external trashes: %w", err)
+	}
+
+	for _, ext := range s.externalTrashes {
+		trashDirs = append(trashDirs, ext.root)
+	}
+
+	return trashDirs, nil
+}

--- a/internal/ui/components.go
+++ b/internal/ui/components.go
@@ -19,6 +19,8 @@ func Confirm(prompt string) bool {
 	m.Prompt = prompt
 	m.DefaultValue = confirm.Denied
 	m.Rendering = confirm.ImmediateInput
+	m.AcceptedDecisionText = "Yes"
+	m.DeniedDecisionText = "No"
 
 	p := tea.NewProgram(&m)
 	if _, err := p.Run(); err != nil {

--- a/internal/ui/components.go
+++ b/internal/ui/components.go
@@ -21,6 +21,7 @@ func Confirm(prompt string) bool {
 	m.Rendering = confirm.ImmediateInput
 	m.AcceptedDecisionText = "Yes"
 	m.DeniedDecisionText = "No"
+	m.Placeholder = "y/N"
 
 	p := tea.NewProgram(&m)
 	if _, err := p.Run(); err != nil {

--- a/internal/ui/components/confirm/confirm.go
+++ b/internal/ui/components/confirm/confirm.go
@@ -106,6 +106,12 @@ type Model struct {
 	// DeniedDecisionText is the text to display to a user which they will select for Denied confirmations
 	DeniedDecisionText string
 
+	// AcceptedInputText is the text that user can input for acceptance (e.g. "y")
+	AcceptedInputText string
+
+	// DeniedInputText is the text that user can input for denial (e.g. "n")
+	DeniedInputText string
+
 	// ChooserIndicator is a rune displayed to the user for HorizontalSelection or VerticalSelection rendering
 	ChooserIndicator rune
 
@@ -130,8 +136,10 @@ type Model struct {
 func New() Model {
 	m := Model{
 		PromptPrefix:         "? ",
-		AcceptedDecisionText: "y",
-		DeniedDecisionText:   "n",
+		AcceptedDecisionText: "Yes",
+		DeniedDecisionText:   "No",
+		AcceptedInputText:    "y",
+		DeniedInputText:      "n",
 		ChooserIndicator:     '➤',
 		Styles: Styles{
 			PromptPrefix:     lipgloss.NewStyle().Foreground(lipgloss.Color(colors.PromptPrefix)),

--- a/internal/ui/components/confirm/rendering.go
+++ b/internal/ui/components/confirm/rendering.go
@@ -178,17 +178,17 @@ func (i *inputRenderer) Init() tea.Cmd {
 	} else {
 		var s strings.Builder
 		if i.m.DefaultValue == Accepted {
-			s.WriteString(strings.ToUpper(i.m.AcceptedDecisionText))
+			s.WriteString(strings.ToUpper(i.m.AcceptedInputText))
 		} else {
-			s.WriteString(i.m.AcceptedDecisionText)
+			s.WriteString(i.m.AcceptedInputText)
 		}
 
 		s.WriteString("/")
 
 		if i.m.DefaultValue == Denied {
-			s.WriteString(strings.ToUpper(i.m.DeniedDecisionText))
+			s.WriteString(strings.ToUpper(i.m.DeniedInputText))
 		} else {
-			s.WriteString(i.m.DeniedDecisionText)
+			s.WriteString(i.m.DeniedInputText)
 		}
 
 		input.Placeholder = s.String()

--- a/internal/ui/table/table.go
+++ b/internal/ui/table/table.go
@@ -1,0 +1,44 @@
+package table
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/dustin/go-humanize"
+	"github.com/fatih/color"
+)
+
+const (
+	timeFormat = "2006-01-02 15:04:05"
+)
+
+type FileEntry interface {
+	GetName() string
+	GetDeletedAt() time.Time
+}
+
+func PrintFiles[T FileEntry](files []T, showRelativeTime bool) {
+	green := color.New(color.FgHiGreen).SprintfFunc()
+	white := color.New(color.FgWhite).SprintfFunc()
+
+	fmt.Printf("%s %s %s\n",
+		green("%-20s", "Deleted At"),
+		green("%-18s", ""),
+		green("%-30s", "Path"),
+	)
+
+	for _, file := range files {
+		var middleColumn string
+		if showRelativeTime {
+			middleColumn = "(" + humanize.Time(file.GetDeletedAt()) + ")"
+		}
+
+		fmt.Printf("%s %s %s\n",
+			white("%-20s", file.GetDeletedAt().Format(timeFormat)),
+			white("%-18s", middleColumn),
+			white("%-30s", file.GetName()),
+		)
+	}
+
+	fmt.Println()
+}

--- a/internal/utils/duration/duration.go
+++ b/internal/utils/duration/duration.go
@@ -1,0 +1,100 @@
+package duration
+
+import (
+	"errors"
+	"fmt"
+	"strconv"
+	"strings"
+	"time"
+	"unicode"
+)
+
+var unitMap = map[string]string{
+	"h":      "h",
+	"hour":   "h",
+	"hours":  "h",
+	"d":      "d",
+	"day":    "d",
+	"days":   "d",
+	"w":      "w",
+	"week":   "w",
+	"weeks":  "w",
+	"m":      "m",
+	"month":  "m",
+	"months": "m",
+	"y":      "y",
+	"year":   "y",
+	"years":  "y",
+}
+
+var unitDurations = map[string]time.Duration{
+	"h": 1 * time.Hour,
+	"d": 24 * time.Hour,
+	"w": 7 * 24 * time.Hour,
+	"m": 30 * 24 * time.Hour,
+	"y": 365 * 24 * time.Hour,
+}
+
+var (
+	// ErrInvalidFormat indicates the input duration string contains invalid characters
+	ErrInvalidFormat = errors.New("invalid duration format")
+
+	// ErrInvalidNumber indicates the numeric part is invalid or not positive
+	ErrInvalidNumber = errors.New("invalid duration number")
+
+	// ErrInvalidUnit indicates the unit part is not recognized
+	ErrInvalidUnit = errors.New("invalid duration unit")
+)
+
+func Parse(input string) (time.Duration, error) {
+	if input = strings.TrimSpace(input); input == "" {
+		return 0, fmt.Errorf("%w: empty input", ErrInvalidFormat)
+	}
+
+	numStr, unit, err := splitNumberAndUnit(strings.ToLower(input))
+	if err != nil {
+		return 0, fmt.Errorf("%w: invalid characters", ErrInvalidFormat)
+	}
+
+	num, err := strconv.Atoi(numStr)
+	if err != nil {
+		return 0, fmt.Errorf("%w: must be a number", ErrInvalidNumber)
+	}
+
+	if num < 0 {
+		return 0, fmt.Errorf("%w: must be positive", ErrInvalidNumber)
+	}
+
+	if unit == "" {
+		return 0, fmt.Errorf("%w: missing unit", ErrInvalidFormat)
+	}
+
+	mappedUnit, exists := unitMap[unit]
+	if !exists {
+		return 0, fmt.Errorf("%w: '%s' (supported: h, d, w, m, y)", ErrInvalidUnit, unit)
+	}
+
+	return time.Duration(num) * unitDurations[mappedUnit], nil
+}
+
+func splitNumberAndUnit(input string) (string, string, error) {
+	input = strings.TrimSpace(input)
+	if input == "" {
+		return "", "", fmt.Errorf("%w: empty input", ErrInvalidFormat)
+	}
+
+	numPart := strings.Builder{}
+	unitPart := strings.Builder{}
+
+	for _, r := range input {
+		switch {
+		case unicode.IsDigit(r):
+			numPart.WriteRune(r)
+		case unicode.IsLetter(r):
+			unitPart.WriteRune(r)
+		default:
+			return "", "", ErrInvalidFormat
+		}
+	}
+	return numPart.String(), unitPart.String(), nil
+}

--- a/internal/utils/duration/duration_test.go
+++ b/internal/utils/duration/duration_test.go
@@ -1,0 +1,232 @@
+package duration
+
+import (
+	"errors"
+	"testing"
+	"time"
+)
+
+func TestParse(t *testing.T) {
+	tests := []struct {
+		name    string
+		input   string
+		want    time.Duration
+		wantErr error
+	}{
+		{
+			name:    "empty string",
+			input:   "",
+			wantErr: ErrInvalidFormat,
+		},
+		{
+			name:    "invalid characters",
+			input:   "1d!",
+			wantErr: ErrInvalidFormat,
+		},
+		{
+			name:    "no number",
+			input:   "d",
+			wantErr: ErrInvalidNumber,
+		},
+		{
+			name:  "zero",
+			input: "0d",
+			want:  0,
+		},
+		{
+			name:    "negative number",
+			input:   "-1d",
+			wantErr: ErrInvalidFormat,
+		},
+		{
+			name:    "invalid unit",
+			input:   "1x",
+			wantErr: ErrInvalidUnit,
+		},
+		{
+			name:  "1 hour",
+			input: "1h",
+			want:  time.Hour,
+		},
+		{
+			name:  "1 hour (full word)",
+			input: "1hour",
+			want:  time.Hour,
+		},
+		{
+			name:  "2 hours (plural)",
+			input: "2hours",
+			want:  2 * time.Hour,
+		},
+		{
+			name:  "1 day",
+			input: "1d",
+			want:  24 * time.Hour,
+		},
+		{
+			name:  "1 day (full word)",
+			input: "1day",
+			want:  24 * time.Hour,
+		},
+		{
+			name:  "2 days (plural)",
+			input: "2days",
+			want:  48 * time.Hour,
+		},
+		{
+			name:  "1 week",
+			input: "1w",
+			want:  7 * 24 * time.Hour,
+		},
+		{
+			name:  "1 week (full word)",
+			input: "1week",
+			want:  7 * 24 * time.Hour,
+		},
+		{
+			name:  "2 weeks (plural)",
+			input: "2weeks",
+			want:  2 * 7 * 24 * time.Hour,
+		},
+		{
+			name:  "1 month",
+			input: "1m",
+			want:  30 * 24 * time.Hour,
+		},
+		{
+			name:  "1 month (full word)",
+			input: "1month",
+			want:  30 * 24 * time.Hour,
+		},
+		{
+			name:  "2 months (plural)",
+			input: "2months",
+			want:  2 * 30 * 24 * time.Hour,
+		},
+		{
+			name:  "1 year",
+			input: "1y",
+			want:  365 * 24 * time.Hour,
+		},
+		{
+			name:  "1 year (full word)",
+			input: "1year",
+			want:  365 * 24 * time.Hour,
+		},
+		{
+			name:  "2 years (plural)",
+			input: "2years",
+			want:  2 * 365 * 24 * time.Hour,
+		},
+		{
+			name:  "mixed case",
+			input: "1DaY",
+			want:  24 * time.Hour,
+		},
+		{
+			name:  "with spaces",
+			input: " 1d ",
+			want:  24 * time.Hour,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := Parse(tt.input)
+			if tt.wantErr != nil {
+				if err == nil {
+					t.Errorf("Parse(%q) should return error", tt.input)
+					return
+				}
+				if !errors.Is(err, tt.wantErr) {
+					t.Errorf("Parse(%q) error = %v, want %v", tt.input, err, tt.wantErr)
+				}
+				return
+			}
+			if err != nil {
+				t.Errorf("Parse(%q) unexpected error: %v", tt.input, err)
+				return
+			}
+			if got != tt.want {
+				t.Errorf("Parse(%q) = %v, want %v", tt.input, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestSplitNumberAndUnit(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		wantNum  string
+		wantUnit string
+		wantErr  error
+	}{
+		{
+			name:    "empty string",
+			input:   "",
+			wantErr: ErrInvalidFormat,
+		},
+		{
+			name:     "only number",
+			input:    "1",
+			wantNum:  "1",
+			wantUnit: "",
+		},
+		{
+			name:     "only unit",
+			input:    "d",
+			wantNum:  "",
+			wantUnit: "d",
+		},
+		{
+			name:     "valid input",
+			input:    "1d",
+			wantNum:  "1",
+			wantUnit: "d",
+		},
+		{
+			name:     "valid input with full word",
+			input:    "1day",
+			wantNum:  "1",
+			wantUnit: "day",
+		},
+		{
+			name:    "invalid character",
+			input:   "1d!",
+			wantErr: ErrInvalidFormat,
+		},
+		{
+			name:     "with spaces",
+			input:    " 1d ",
+			wantNum:  "1",
+			wantUnit: "d",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			gotNum, gotUnit, err := splitNumberAndUnit(tt.input)
+			if tt.wantErr != nil {
+				if err == nil {
+					t.Errorf("splitNumberAndUnit(%q) should return error", tt.input)
+					return
+				}
+				if !errors.Is(err, tt.wantErr) {
+					t.Errorf("splitNumberAndUnit(%q) error = %v, want %v", tt.input, err, tt.wantErr)
+				}
+				return
+			}
+			if err != nil {
+				t.Errorf("splitNumberAndUnit(%q) unexpected error: %v", tt.input, err)
+				return
+			}
+			if gotNum != tt.wantNum {
+				t.Errorf("splitNumberAndUnit(%q) num = %v, want %v", tt.input, gotNum, tt.wantNum)
+			}
+			if gotUnit != tt.wantUnit {
+				t.Errorf("splitNumberAndUnit(%q) unit = %v, want %v", tt.input, gotUnit, tt.wantUnit)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## WHAT

This PR introduces a new `--prune` option to manage trash contents effectively. It allows users to:

- Remove files older than a specified duration (`gomi --prune=30d`)
- Remove files within a time range (`gomi --prune=2m,3m`)
- Clean up orphaned metadata files (`gomi --prune=orphans`)

See the README for detailed documentation and examples.

<img src="https://github.com/user-attachments/assets/3271a59b-ea7f-476e-93b9-57eeea5d1639" width="500">



## WHY

While `gomi` safely moves files to trash instead of immediate deletion, the trash itself can accumulate a large number of files over time. This can lead to:

1. Disk space inefficiency
2. Cluttered trash making it harder to find recently deleted files
3. Orphaned metadata files causing inconsistencies

This feature helps users maintain a clean and efficient trash directory while still maintaining the safety benefits of `gomi`.


## Credits
The pruning feature is inspired by [gtrash](https://github.com/umlx5h/gtrash). Thanks for the excellent implementation!