### PR TITLE
Implement UI-based Strict Confirmation (Following Terminal Prompt)

### DIFF
--- a/internal/ui/components.go
+++ b/internal/ui/components.go
@@ -21,7 +21,7 @@ func Confirm(prompt string) bool {
 	m.Rendering = confirm.ImmediateInput
 	m.AcceptedDecisionText = "Yes"
 	m.DeniedDecisionText = "No"
-	m.Placeholder = "y/N"
+	m.Placeholder = "y/n"
 
 	p := tea.NewProgram(&m)
 	if _, err := p.Run(); err != nil {

--- a/internal/ui/state.go
+++ b/internal/ui/state.go
@@ -39,10 +39,11 @@ const (
 )
 
 type ViewState struct {
-	current  ViewType
-	previous ViewType
-	detail   detail
-	preview  preview
+	current      ViewType
+	previous     ViewType
+	detail       detail
+	preview      preview
+	confirmation confirmation
 }
 
 type detail struct {
@@ -53,6 +54,19 @@ type detail struct {
 type preview struct {
 	available bool
 }
+type confirmation struct {
+	state    ConfirmState
+	files    []File
+	yesInput string
+}
+
+// ConfirmState represents the confirmation dialog state
+type ConfirmState string
+
+const (
+	ConfirmStateYesNo   ConfirmState = "yn"
+	ConfirmStateTypeYES ConfirmState = "yes"
+)
 
 // NewViewState creates a new ViewState with default values
 func NewViewState() *ViewState {
@@ -65,6 +79,9 @@ func NewViewState() *ViewState {
 		},
 		preview: preview{
 			available: true,
+		},
+		confirmation: confirmation{
+			state: ConfirmStateYesNo,
 		},
 	}
 }
@@ -95,4 +112,46 @@ func (v *ViewState) FormatDate(t time.Time) string {
 		return t.Format(time.DateTime)
 	}
 	return humanize.Time(t)
+}
+
+// SetConfirmState sets the confirmation dialog state
+func (v *ViewState) SetConfirmState(state ConfirmState, files []File) {
+	v.confirmation.state = state
+	v.confirmation.files = files
+	v.confirmation.yesInput = "" // reset input
+}
+
+// UpdateYesInput updates the YES input state
+func (v *ViewState) UpdateYesInput(char string) {
+	switch len(v.confirmation.yesInput) {
+	case 0:
+		if char == "Y" {
+			v.confirmation.yesInput += char
+		}
+	case 1:
+		if char == "E" {
+			v.confirmation.yesInput += char
+		}
+	case 2:
+		if char == "S" {
+			v.confirmation.yesInput += char
+		}
+	}
+}
+
+// IsYesComplete checks if the complete "YES" has been entered
+func (v *ViewState) IsYesComplete() bool {
+	return v.confirmation.yesInput == "YES"
+}
+
+// ClearYesInput clears the YES input
+func (v *ViewState) ClearYesInput() {
+	v.confirmation.yesInput = ""
+}
+
+// BackspaceYesInput removes the last character from YES input
+func (v *ViewState) BackspaceYesInput() {
+	if len(v.confirmation.yesInput) > 0 {
+		v.confirmation.yesInput = v.confirmation.yesInput[:len(v.confirmation.yesInput)-1]
+	}
 }

--- a/internal/ui/styles/styles.go
+++ b/internal/ui/styles/styles.go
@@ -70,12 +70,14 @@ type DialogStyles struct {
 
 // ConfirmStyles contains styles for confirmation prompts
 type ConfirmStyles struct {
-	Prompt     lipgloss.Style
-	Text       lipgloss.Style
-	Indicator  lipgloss.Style
-	Prefix     lipgloss.Style
-	Error      lipgloss.Style
-	Suggestion lipgloss.Style
+	Prompt      lipgloss.Style
+	Text        lipgloss.Style
+	Indicator   lipgloss.Style
+	Prefix      lipgloss.Style
+	Success     lipgloss.Style
+	Error       lipgloss.Style
+	Suggestion  lipgloss.Style
+	Placeholder lipgloss.Style
 }
 
 // New creates a new Styles instance with the provided configuration
@@ -194,11 +196,15 @@ func New(cfg config.UI) *Styles {
 			Foreground(lipgloss.Color(cfg.Style.ListView.Selected)),
 		Prefix: lipgloss.NewStyle().
 			Foreground(lipgloss.Color(cfg.Style.ListView.Cursor)),
+		Success: lipgloss.NewStyle().
+			Foreground(lipgloss.Color("#00FF00")),
 		Error: lipgloss.NewStyle().
 			Foreground(lipgloss.Color("#FF0000")),
 		Suggestion: lipgloss.NewStyle().
 			Foreground(lipgloss.AdaptiveColor{Light: "#A49FA5", Dark: "#777777"}).
 			Italic(true),
+		Placeholder: lipgloss.NewStyle().
+			Foreground(lipgloss.AdaptiveColor{Light: "#A49FA5", Dark: "#777777"}),
 	}
 
 	return s

--- a/internal/ui/view_confirm.go
+++ b/internal/ui/view_confirm.go
@@ -2,6 +2,7 @@ package ui
 
 import (
 	"fmt"
+	"log/slog"
 	"strings"
 
 	"github.com/charmbracelet/lipgloss"
@@ -18,22 +19,22 @@ func (m Model) confirmView() string {
 		baseView = m.detailView()
 	}
 
-	_, displayText, isSingleTarget := m.prepareDeleteTarget()
-	dialogContent := m.formatDeleteConfirmation(displayText, isSingleTarget)
+	files := m.state.confirmation.files
+	slog.Debug("selected files on confirm view", "files", files)
+
+	var dialogContent string
+	if m.state.confirmation.state == ConfirmStateTypeYES {
+		dialogContent = m.formatConfirmationTypeYES(files)
+	} else {
+		dialogContent = m.formatConfirmation(files)
+	}
 
 	return m.renderDialogOverBase(baseView, dialogContent)
 }
 
-// prepareDeleteTarget prepares target files information for confirmation
-func (m Model) prepareDeleteTarget() ([]File, string, bool) {
-	files := selectionManager.items
-	if len(files) == 0 {
-		// Single target on cursor line
-		file := m.list.SelectedItem().(File)
-		return []File{file}, "'" + file.Title() + "'", true
-	}
-
-	// Multiple files from selection manager
+// formatConfirmation formats the confirmation dialog content
+func (m Model) formatConfirmation(files []File) string {
+	// this function expects that a length of files is always 1
 	quotedNames := strings.Join(
 		lo.Map(files, func(f File, index int) string {
 			return "'" + f.Title() + "'"
@@ -41,32 +42,80 @@ func (m Model) prepareDeleteTarget() ([]File, string, bool) {
 		", ",
 	)
 
-	isSingleTarget := len(files) == 1
-	dialogMaxWidth := defaultWidth - 6 // border (2) + padding (2) + buffer (2)
-	if len(files) > 1 && len(quotedNames) > dialogMaxWidth {
-		return files, fmt.Sprintf("%d files", len(files)), true
+	contents := []string{
+		"Are you sure you want to",
+		quotedNames + "?",
+		"",
+		"(y/n)",
 	}
 
-	return files, quotedNames, isSingleTarget
+	return m.styles.RenderDialog(
+		lipgloss.JoinVertical(lipgloss.Center, contents...),
+	)
 }
 
-// formatDeleteConfirmation formats the confirmation dialog content
-func (m Model) formatDeleteConfirmation(target string, isSingleTarget bool) string {
+// formatConfirmationTypeYES formats the confirmation dialog content for strict YES typing verification
+// It displays the current input state with visual feedback and requires the user to type "YES" exactly
+func (m Model) formatConfirmationTypeYES(files []File) string {
+	// Display the current input state
+	const fullText = "YES"
+	var inputDisplay string
+
+	for i, char := range fullText {
+		if i < len(m.state.confirmation.yesInput) {
+			// Already typed characters shown in normal text
+			inputDisplay += m.styles.Confirm.Text.Render(string(m.state.confirmation.yesInput[i]))
+		} else {
+			// Not yet typed characters shown as placeholder
+			// instead of using a static underscore character for placeholders,
+			// it uses the actual character from fullText that needs to be typed (Y, E, or S).
+			//
+			// inputDisplay += m.styles.Confirm.Placeholder.Render(string(char))
+			_ = char
+			inputDisplay += m.styles.Confirm.Placeholder.Render("_")
+		}
+	}
+
+	// Icon indicating completion status
+	var statusIcon string
+	if m.state.IsYesComplete() {
+		statusIcon = m.styles.Confirm.Success.Render(" ✓")
+	} else {
+		statusIcon = m.styles.Confirm.Error.Render(" ✗")
+	}
+
+	quotedNames := strings.Join(
+		lo.Map(files, func(f File, index int) string {
+			return "'" + f.Title() + "'"
+		}),
+		", ",
+	)
+
 	var contents []string
-	if isSingleTarget {
+	dialogMaxWidth := defaultWidth - 6 // border (2) + padding (2) + buffer (2)
+	if len(files) > 1 && len(quotedNames) > dialogMaxWidth {
 		contents = []string{
 			"Are you sure you want to",
-			"completely delete " + target + "?",
-			"",
-			"(y/n)",
+			"completely delete " + fmt.Sprintf("%d files", len(files)) + "?",
 		}
 	} else {
 		contents = []string{
 			"Are you sure you want to completely delete",
-			target + "?",
-			"",
-			"(y/n)",
+			quotedNames + "?",
 		}
+	}
+
+	contents = append(contents, []string{
+		"",
+		"Type YES to confirm",
+		"",
+		inputDisplay + statusIcon,
+		"",
+		"  (ESC to cancel, Enter to confirm)  ",
+	}...)
+
+	if m.state.IsYesComplete() && len(contents) > 4 {
+		contents[3] = "YES confirmed! Press Enter to delete"
 	}
 
 	return m.styles.RenderDialog(


### PR DESCRIPTION
## WHAT

This PR enhances the confirmation dialog in the UI by introducing two distinct confirmation modes:

1. Standard Yes/No Confirmation
   - For single file deletions
   - Quick confirmation with 'y/n' prompt
2. Strict "YES" Typing Confirmation
   - For multiple file deletions
   - Requires typing "YES" exactly
   - Provides real-time visual feedback
   - Prevents accidental deletions

Key Implementation Details:

- Added new `confirmation` struct to `ViewState` to track confirmation state
- Introduced `ConfirmState` type with two modes: `ConfirmStateYesNo` and `ConfirmStateTypeYES`
- Created methods to handle character-by-character input validation
- Added new styling for confirmation dialog with success and error indicators
- Implemented input tracking for "YES" with backspace support


<img src="https://github.com/user-attachments/assets/1152cf4d-76a8-4bcd-92b6-89db63f2aa45" width="600">


## WHY

This implementation extends the previous work in [PR #85](https://github.com/babarot/gomi/pull/85), bringing the strict confirmation mechanism from the terminal prompt to the restore UI. 

The motivation remains the same: preventing accidental deletions by:
- Requiring more deliberate user confirmation
- Making users consciously type out their confirmation
- Providing clear visual feedback during the confirmation process

By implementing this in the UI layer, we provide a consistent and safe deletion experience across different interaction modes.

