### PR TITLE
Make forbidden paths configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,6 +169,22 @@ core:
 
     home_fallback: true # If true, fallbacks to home trash when external trash fails
 
+    forbidden_paths:    # List of paths that cannot be moved to trash for safety
+      - "$HOME/.local/share/Trash"
+      - "$HOME/.trash"
+      - "$XDG_DATA_HOME/Trash"
+      - "/tmp/Trash"
+      - "/var/tmp/Trash"
+      - "$HOME/.gomi"
+      - "/"
+      - "/etc"
+      - "/usr"
+      - "/var"
+      - "/bin"
+      - "/sbin"
+      - "/lib"
+      - "/lib64"
+
   restore:
     confirm: false      # If true, prompts for confirmation before restoring (yes/no)
     verbose: true       # If true, displays detailed restoration information

--- a/internal/cli/put.go
+++ b/internal/cli/put.go
@@ -13,29 +13,6 @@ import (
 	"golang.org/x/sync/errgroup"
 )
 
-// List of forbidden paths that cannot be moved to trash
-var forbiddenPaths = []string{
-	// Default trash-related paths
-	"$HOME/.local/share/Trash",
-	"$HOME/.trash",
-	"$XDG_DATA_HOME/Trash",
-	"/tmp/Trash",
-	"/var/tmp/Trash",
-
-	// gomi dir
-	"$HOME/.gomi",
-
-	// Critical system directories
-	"/",
-	"/etc",
-	"/usr",
-	"/var",
-	"/bin",
-	"/sbin",
-	"/lib",
-	"/lib64",
-}
-
 // Put moves files to trash
 func (c *CLI) Put(args []string) error {
 	slog.Debug("cli.put started")
@@ -80,7 +57,7 @@ func (c *CLI) processFile(arg string, failed *syncStringSlice) error {
 	}
 
 	// Check for forbidden paths
-	if isForbiddenPath(expandedPath) {
+	if c.isForbiddenPath(expandedPath) {
 		failed.Append(arg)
 		return fmt.Errorf("refusing to remove forbidden path: %q", arg)
 	}
@@ -161,10 +138,10 @@ func expandPath(path string) (string, error) {
 }
 
 // isForbiddenPath checks if the given path is in the forbidden paths list
-func isForbiddenPath(path string) bool {
+func (c *CLI) isForbiddenPath(path string) bool {
 	path = filepath.Clean(path)
 
-	for _, forbiddenPath := range forbiddenPaths {
+	for _, forbiddenPath := range c.config.Core.Trash.ForbiddenPaths {
 		// Expand forbidden path with environment variables
 		expandedForbiddenPath := os.ExpandEnv(forbiddenPath)
 		expandedForbiddenPath = filepath.Clean(expandedForbiddenPath)

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -51,6 +51,9 @@ type TrashConfig struct {
 
 	// GomiDir specifies the trash directory for legacy mode
 	GomiDir string `yaml:"gomi_dir" validate:"omitempty,validDirPath"`
+
+	// List of forbidden paths that cannot be moved to trash
+	ForbiddenPaths []string `yaml:"forbidden_paths"`
 }
 
 // RestoreConfig defines settings for file restoration behavior

--- a/internal/config/defaults.go
+++ b/internal/config/defaults.go
@@ -16,6 +16,25 @@ func NewDefaultConfig() *Config {
 				Strategy:     "auto",
 				HomeFallback: true,
 				GomiDir:      filepath.Join(homedir, ".gomi"),
+				ForbiddenPaths: []string{
+					// Default trash-related paths
+					"$HOME/.local/share/Trash",
+					"$HOME/.trash",
+					"$XDG_DATA_HOME/Trash",
+					"/tmp/Trash",
+					"/var/tmp/Trash",
+					// gomi dir
+					"$HOME/.gomi",
+					// Critical system directories
+					"/",
+					"/etc",
+					"/usr",
+					"/var",
+					"/bin",
+					"/sbin",
+					"/lib",
+					"/lib64",
+				},
 			},
 			Restore: RestoreConfig{
 				Confirm: true,


### PR DESCRIPTION


## What
- Moved hardcoded forbidden paths from code to configuration
- Added `forbidden_paths` option to the trash config section 
- Made the default list match the previous hardcoded values
- Updated path checking to use configuration values instead of hardcoded list

## Why
This addresses issue #94 where the hardcoded forbidden paths were too restrictive for certain use cases. Users reported being unable to remove files in paths like `/var/tmp/` and `/usr/local/*`.

By making these paths configurable in `config.yaml`, users can now customize which paths should be protected based on their specific needs, while still maintaining safety mechanisms where appropriate. This provides more flexibility for power users while preserving the default safety restrictions for most users.

The default configuration still includes all the previous safety measures, ensuring that critical system directories remain protected unless explicitly configured otherwise.