### PR TITLE
Customise styles on the filter matching/prompt

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,13 @@ Restore a file to its original location. The `--restore` flag is a bit long, so 
 rm -b
 ```
 
+This launches an interactive file browser where you can:
+- Navigate through trashed files using arrow keys
+- Press `/` to start searching/filtering files by name
+- Press `Tab` to select multiple files for restoration
+- Press `Space` to preview file contents
+- Press `Enter` to restore selected files
+
 ## Installation
 
 ### Getting Started in Seconds
@@ -206,8 +213,10 @@ ui:
     directory_command: ls -F -A --color=always
   style:
     list_view:
-      cursor: "#AD58B4"   # purple
-      selected: "#5FB458" # green
+      cursor: "#AD58B4"         # purple - color of the cursor border and text
+      selected: "#5FB458"       # green - color of selected files
+      filter_match: "#F39C12"   # orange - color of matched text when searching
+      filter_prompt: "#7AA2F7"  # blue - color of the "Filter:" prompt text
       indent_on_select: false
     detail_view:
       border: "#FFFFFF"

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -111,6 +111,8 @@ type ListViewConfig struct {
 	IndentOnSelect bool   `yaml:"indent_on_select"`
 	Cursor         string `yaml:"cursor" validate:"validColorCode|allowEmpty"`
 	Selected       string `yaml:"selected" validate:"validColorCode|allowEmpty"`
+	FilterMatch    string `yaml:"filter_match" validate:"validColorCode|allowEmpty"`
+	FilterPrompt   string `yaml:"filter_prompt" validate:"validColorCode|allowEmpty"`
 }
 
 // DetailViewConfig configures the detailed file view
@@ -339,5 +341,15 @@ func (c *Config) setDefault() {
 	// Since deletion is a potentially destructive operation, use a distinctive color to emphasize caution
 	if c.UI.Style.DeletionDialog == "" {
 		c.UI.Style.DeletionDialog = "205"
+	}
+	
+	// Set color for filter match highlighting
+	if c.UI.Style.ListView.FilterMatch == "" {
+		c.UI.Style.ListView.FilterMatch = "#F39C12"
+	}
+	
+	// Set color for filter prompt
+	if c.UI.Style.ListView.FilterPrompt == "" {
+		c.UI.Style.ListView.FilterPrompt = "#7AA2F7"
 	}
 }

--- a/internal/config/defaults.go
+++ b/internal/config/defaults.go
@@ -57,6 +57,8 @@ func NewDefaultConfig() *Config {
 					IndentOnSelect: true,
 					Cursor:         "#AD58B4",
 					Selected:       "#5FB458",
+					FilterMatch:    "#F39C12",
+					FilterPrompt:   "#7AA2F7",
 				},
 				DetailView: DetailViewConfig{
 					Border: "#EEEEDD",

--- a/internal/ui/delegate.go
+++ b/internal/ui/delegate.go
@@ -33,7 +33,8 @@ type RestoreItemStyles struct {
 	DimmedTitle lipgloss.Style
 	DimmedDesc  lipgloss.Style
 
-	FilterMatch lipgloss.Style
+	FilterMatch  lipgloss.Style
+	FilterPrompt lipgloss.Style
 }
 
 func NewRestoreItemStyles(cfg config.UI) (s RestoreItemStyles) {
@@ -68,7 +69,13 @@ func NewRestoreItemStyles(cfg config.UI) (s RestoreItemStyles) {
 	s.DimmedDesc = s.DimmedTitle.
 		Foreground(lipgloss.AdaptiveColor{Light: "#C2B8C2", Dark: "#4D4D4D"})
 
-	s.FilterMatch = lipgloss.NewStyle().Underline(true)
+	s.FilterMatch = lipgloss.NewStyle().
+		Foreground(lipgloss.Color(cfg.Style.ListView.FilterMatch)).
+		Underline(true)
+
+	s.FilterPrompt = lipgloss.NewStyle().
+		Foreground(lipgloss.Color(cfg.Style.ListView.FilterPrompt)).
+		Underline(true)
 
 	s.SelectedTitle = lipgloss.NewStyle().
 		Foreground(lipgloss.AdaptiveColor{Light: selected, Dark: selected}).

--- a/internal/ui/model.go
+++ b/internal/ui/model.go
@@ -9,6 +9,7 @@ import (
 	"github.com/charmbracelet/bubbles/list"
 	"github.com/charmbracelet/bubbles/paginator"
 	"github.com/charmbracelet/bubbles/viewport"
+	"github.com/charmbracelet/lipgloss"
 )
 
 // Model represents the main UI model following the Bubble Tea pattern
@@ -72,6 +73,11 @@ func NewModel(manager *trash.Manager, files []*trash.File, cfg *config.Config) M
 	l.SetShowTitle(false)
 	l.SetShowHelp(false) // do not use default help of list model
 	l.DisableQuitKeybindings()
+	
+	// Configure filter prompt style
+	l.FilterInput.PromptStyle = lipgloss.NewStyle().
+		Foreground(lipgloss.Color(cfg.UI.Style.ListView.FilterPrompt)).
+		Bold(true)
 
 	// Set paginator type based on config
 	switch cfg.UI.Paginator {

--- a/internal/ui/styles/styles.go
+++ b/internal/ui/styles/styles.go
@@ -18,12 +18,13 @@ type Styles struct {
 
 // ListStyles contains styles for list view
 type ListStyles struct {
-	Normal      lipgloss.Style
-	Selected    lipgloss.Style
-	Cursor      lipgloss.Style
-	Description lipgloss.Style
-	Title       lipgloss.Style
-	FilterMatch lipgloss.Style
+	Normal       lipgloss.Style
+	Selected     lipgloss.Style
+	Cursor       lipgloss.Style
+	Description  lipgloss.Style
+	Title        lipgloss.Style
+	FilterMatch  lipgloss.Style
+	FilterPrompt lipgloss.Style
 }
 
 // DetailStyles contains styles for detail view
@@ -103,7 +104,11 @@ func New(cfg config.UI) *Styles {
 			Padding(0, 1).
 			Bold(true),
 		FilterMatch: lipgloss.NewStyle().
+			Foreground(lipgloss.Color(cfg.Style.ListView.FilterMatch)).
 			Underline(true),
+		FilterPrompt: lipgloss.NewStyle().
+			Foreground(lipgloss.Color(cfg.Style.ListView.FilterPrompt)).
+			Bold(true),
 	}
 
 	s.Detail = DetailStyles{


### PR DESCRIPTION
## WHAT
Added configurable colors for the search filter in the `--restore` interactive menu, addressing the user request for customizable filter appearance.


New Configuration Options:
```yaml
ui:
  style:
    list_view:
      filter_match: "#F39C12"   # orange - highlight matched text
      filter_prompt: "#7AA2F7"  # blue - filter prompt color
```


Users can now customize both the filter prompt color and the highlighted matched text color to match their preferred theme.
## WHY
#98