### PR TITLE
Add comprehensive unit tests across all non-UI-component packages

### DIFF
--- a/internal/cli/cli_test.go
+++ b/internal/cli/cli_test.go
@@ -1,0 +1,177 @@
+package cli
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/babarot/gomi/internal/config"
+	"github.com/babarot/gomi/internal/utils/log"
+)
+
+func TestExpandPath(t *testing.T) {
+	tests := []struct {
+		input string
+		want  string
+	}{
+		{"foo.txt", "foo.txt"},
+		{"./foo.txt", "foo.txt"},
+		{"foo/../bar.txt", "bar.txt"},
+		{"foo/./bar.txt", "foo/bar.txt"},
+		{"/absolute/path", "/absolute/path"},
+		{"", "."},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.input, func(t *testing.T) {
+			got, err := expandPath(tt.input)
+			if err != nil {
+				t.Fatalf("expandPath(%q) error = %v", tt.input, err)
+			}
+			if got != tt.want {
+				t.Errorf("expandPath(%q) = %q, want %q", tt.input, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestExpandWindowsPaths(t *testing.T) {
+	// Without actual glob matches, args should be returned as-is
+	args := []string{"noexist*.xyz", "plain.txt"}
+	got := expandWindowsPaths(args)
+	if len(got) != 2 {
+		t.Fatalf("expandWindowsPaths() returned %d items, want 2", len(got))
+	}
+	if got[1] != "plain.txt" {
+		t.Errorf("expandWindowsPaths()[1] = %q, want %q", got[1], "plain.txt")
+	}
+}
+
+func TestExpandWindowsPaths_WithMatches(t *testing.T) {
+	dir := t.TempDir()
+
+	// Create temp files to match glob
+	for _, name := range []string{"a.tmp", "b.tmp"} {
+		if err := os.WriteFile(filepath.Join(dir, name), []byte("x"), 0644); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	args := []string{dir + "/*.tmp"}
+	got := expandWindowsPaths(args)
+	if len(got) != 2 {
+		t.Fatalf("expandWindowsPaths() returned %d items, want 2", len(got))
+	}
+}
+
+func TestDetermineLogLevel(t *testing.T) {
+	tests := []struct {
+		input string
+		want  log.Level
+	}{
+		{"debug", log.DebugLevel},
+		{"info", log.InfoLevel},
+		{"warn", log.WarnLevel},
+		{"error", log.ErrorLevel},
+		{"unknown", log.DebugLevel},
+		{"", log.DebugLevel},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.input, func(t *testing.T) {
+			got := determineLogLevel(tt.input)
+			if got != tt.want {
+				t.Errorf("determineLogLevel(%q) = %v, want %v", tt.input, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestIsForbiddenPath(t *testing.T) {
+	cli := &CLI{
+		config: &config.Config{
+			Core: config.Core{
+				Trash: config.TrashConfig{
+					ForbiddenPaths: []string{
+						"/",
+						"/etc",
+						"/usr",
+						"$HOME/.gomi",
+					},
+				},
+			},
+		},
+	}
+
+	tests := []struct {
+		path string
+		want bool
+	}{
+		{"/", true},
+		{"/etc", true},
+		{"/etc/hosts", true},     // sub-path of /etc
+		{"/usr", true},           // exact match
+		{"/usr/local/bin", true}, // sub-path of /usr
+		{"/tmp/foo", false},
+		{"/home/user/file.txt", false},
+		{"relative/path", false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.path, func(t *testing.T) {
+			got := cli.isForbiddenPath(tt.path)
+			if got != tt.want {
+				t.Errorf("isForbiddenPath(%q) = %v, want %v", tt.path, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestSyncStringSlice(t *testing.T) {
+	s := &syncStringSlice{}
+
+	// Empty initially
+	if got := s.Get(); len(got) != 0 {
+		t.Errorf("empty slice: Get() returned %d items", len(got))
+	}
+
+	// Append and verify
+	s.Append("a")
+	s.Append("b")
+	s.Append("c")
+
+	got := s.Get()
+	if len(got) != 3 {
+		t.Fatalf("Get() returned %d items, want 3", len(got))
+	}
+	if got[0] != "a" || got[1] != "b" || got[2] != "c" {
+		t.Errorf("Get() = %v, want [a b c]", got)
+	}
+
+	// Verify Get() returns a copy (modifying returned slice doesn't affect original)
+	got[0] = "modified"
+	original := s.Get()
+	if original[0] != "a" {
+		t.Error("Get() should return a copy, not a reference")
+	}
+}
+
+func TestSyncStringSlice_Concurrent(t *testing.T) {
+	s := &syncStringSlice{}
+	done := make(chan struct{})
+
+	// Concurrent writes
+	for i := 0; i < 100; i++ {
+		go func() {
+			s.Append("item")
+			done <- struct{}{}
+		}()
+	}
+	for i := 0; i < 100; i++ {
+		<-done
+	}
+
+	if got := s.Get(); len(got) != 100 {
+		t.Errorf("concurrent Append: got %d items, want 100", len(got))
+	}
+}

--- a/internal/cli/cli_test.go
+++ b/internal/cli/cli_test.go
@@ -1,11 +1,15 @@
 package cli
 
 import (
+	"bytes"
+	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/babarot/gomi/internal/config"
+	"github.com/babarot/gomi/internal/trash"
 	"github.com/babarot/gomi/internal/utils/log"
 )
 
@@ -173,5 +177,209 @@ func TestSyncStringSlice_Concurrent(t *testing.T) {
 
 	if got := s.Get(); len(got) != 100 {
 		t.Errorf("concurrent Append: got %d items, want 100", len(got))
+	}
+}
+
+func TestVersion_String(t *testing.T) {
+	v := Version{
+		AppName:   "gomi",
+		Version:   "1.0.0",
+		Revision:  "abc123",
+		BuildDate: "2024-01-01",
+	}
+
+	s := v.String()
+	if !strings.Contains(s, "gomi") {
+		t.Error("should contain app name")
+	}
+	if !strings.Contains(s, "1.0.0") {
+		t.Error("should contain version")
+	}
+	if !strings.Contains(s, "abc123") {
+		t.Error("should contain revision")
+	}
+	if !strings.Contains(s, "2024-01-01") {
+		t.Error("should contain build date")
+	}
+	if !strings.Contains(s, appURL) {
+		t.Error("should contain app URL")
+	}
+}
+
+func TestCLI_Run_Version(t *testing.T) {
+	old := os.Stdout
+	r, w, _ := os.Pipe()
+	os.Stdout = w
+
+	cli := CLI{
+		version: Version{
+			AppName:   "gomi",
+			Version:   "1.0.0",
+			Revision:  "abc",
+			BuildDate: "2024-01-01",
+		},
+		option: Option{
+			Meta: MetaOption{Version: true},
+		},
+		config: config.NewDefaultConfig(),
+	}
+
+	err := cli.Run(nil)
+
+	w.Close()
+	os.Stdout = old
+
+	if err != nil {
+		t.Fatalf("Run() error = %v", err)
+	}
+
+	var buf bytes.Buffer
+	buf.ReadFrom(r)
+	output := buf.String()
+	if !strings.Contains(output, "1.0.0") {
+		t.Errorf("version output should contain version, got %q", output)
+	}
+}
+
+func TestCLI_Run_PutNoArgs(t *testing.T) {
+	cli := CLI{
+		option: Option{},
+		config: config.NewDefaultConfig(),
+	}
+
+	err := cli.Run(nil)
+	if err == nil {
+		t.Error("Run() with no args should return error")
+	}
+	if !strings.Contains(err.Error(), "too few arguments") {
+		t.Errorf("unexpected error: %v", err)
+	}
+}
+
+func TestPrune_NoArgs(t *testing.T) {
+	cli := CLI{config: config.NewDefaultConfig()}
+	err := cli.Prune(nil)
+	if err == nil {
+		t.Fatal("Prune(nil) should return error")
+	}
+	if !strings.Contains(err.Error(), "requires an argument") {
+		t.Errorf("unexpected error: %v", err)
+	}
+}
+
+func TestPrune_OrphansWithOtherArgs(t *testing.T) {
+	cli := CLI{config: config.NewDefaultConfig()}
+	err := cli.Prune([]string{"orphans", "30d"})
+	if err == nil {
+		t.Fatal("Prune with orphans + duration should return error")
+	}
+	if !strings.Contains(err.Error(), "cannot be combined") {
+		t.Errorf("unexpected error: %v", err)
+	}
+}
+
+func TestPrune_InvalidDuration(t *testing.T) {
+	cli := CLI{config: config.NewDefaultConfig()}
+	err := cli.Prune([]string{"xyz"})
+	if err == nil {
+		t.Fatal("Prune with invalid duration should return error")
+	}
+}
+
+func TestPrune_EmptyArg(t *testing.T) {
+	cli := CLI{config: config.NewDefaultConfig()}
+	err := cli.Prune([]string{""})
+	if err == nil {
+		t.Fatal("Prune with empty arg should return error")
+	}
+}
+
+func TestParseTrashInfoFile(t *testing.T) {
+	dir := t.TempDir()
+	infoFile := filepath.Join(dir, "test.trashinfo")
+
+	content := fmt.Sprintf("[Trash Info]\nPath=/home/user/test.txt\nDeletionDate=2024-06-15T10:30:00\n")
+	if err := os.WriteFile(infoFile, []byte(content), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	orphan, err := parseTrashInfoFile(infoFile)
+	if err != nil {
+		t.Fatalf("parseTrashInfoFile() error = %v", err)
+	}
+	if orphan.OriginalPath != "/home/user/test.txt" {
+		t.Errorf("OriginalPath = %q, want %q", orphan.OriginalPath, "/home/user/test.txt")
+	}
+	if orphan.DeletedAt.Year() != 2024 || orphan.DeletedAt.Month() != 6 || orphan.DeletedAt.Day() != 15 {
+		t.Errorf("DeletedAt = %v, unexpected", orphan.DeletedAt)
+	}
+	if orphan.TrashInfoPath != infoFile {
+		t.Errorf("TrashInfoPath = %q, want %q", orphan.TrashInfoPath, infoFile)
+	}
+}
+
+func TestParseTrashInfoFile_InvalidDate(t *testing.T) {
+	dir := t.TempDir()
+	infoFile := filepath.Join(dir, "bad.trashinfo")
+	os.WriteFile(infoFile, []byte("Path=/foo\nDeletionDate=not-a-date\n"), 0644)
+
+	_, err := parseTrashInfoFile(infoFile)
+	if err == nil {
+		t.Error("expected error for invalid date")
+	}
+}
+
+func TestParseTrashInfoFile_NonExistent(t *testing.T) {
+	_, err := parseTrashInfoFile("/nonexistent/file.trashinfo")
+	if err == nil {
+		t.Error("expected error for non-existent file")
+	}
+}
+
+func TestPruneArgs_UnmarshalFlag(t *testing.T) {
+	var p PruneArgs
+	if err := p.UnmarshalFlag("30d,orphans"); err != nil {
+		t.Fatalf("UnmarshalFlag() error = %v", err)
+	}
+	if len(p) != 2 {
+		t.Fatalf("expected 2 args, got %d", len(p))
+	}
+	if p[0] != "30d" || p[1] != "orphans" {
+		t.Errorf("args = %v, want [30d orphans]", p)
+	}
+}
+
+func TestOrphanedFile_Getters(t *testing.T) {
+	o := OrphanedFile{
+		TrashInfoName: "test.trashinfo",
+	}
+	if o.GetName() != "test.trashinfo" {
+		t.Errorf("GetName() = %q, want %q", o.GetName(), "test.trashinfo")
+	}
+	if o.GetDeletedAt().IsZero() {
+		// zero value is fine, just make sure it doesn't panic
+	}
+}
+
+func TestFilterFiles(t *testing.T) {
+	dir := t.TempDir()
+
+	// Create a real file to represent an existing trash entry
+	existingFile := filepath.Join(dir, "exists.txt")
+	os.WriteFile(existingFile, []byte("hi"), 0644)
+
+	cli := &CLI{config: config.NewDefaultConfig()}
+
+	files := []*trash.File{
+		{Name: "exists.txt", TrashPath: existingFile},
+		{Name: "gone.txt", TrashPath: "/nonexistent/gone.txt"},
+	}
+
+	filtered := cli.filterFiles(files)
+	if len(filtered) != 1 {
+		t.Fatalf("filterFiles() returned %d files, want 1", len(filtered))
+	}
+	if filtered[0].Name != "exists.txt" {
+		t.Errorf("Name = %q, want %q", filtered[0].Name, "exists.txt")
 	}
 }

--- a/internal/cli/cli_test.go
+++ b/internal/cli/cli_test.go
@@ -21,8 +21,8 @@ func TestExpandPath(t *testing.T) {
 		{"foo.txt", "foo.txt"},
 		{"./foo.txt", "foo.txt"},
 		{"foo/../bar.txt", "bar.txt"},
-		{"foo/./bar.txt", "foo/bar.txt"},
-		{"/absolute/path", "/absolute/path"},
+		{"foo/./bar.txt", filepath.Join("foo", "bar.txt")},
+		{"/absolute/path", filepath.Clean("/absolute/path")},
 		{"", "."},
 	}
 

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -17,6 +17,9 @@ func TestNewDefaultConfig(t *testing.T) {
 	if !cfg.Core.Trash.HomeFallback {
 		t.Error("HomeFallback should be true")
 	}
+	if cfg.Core.Trash.GomiDir == "" {
+		t.Error("GomiDir should not be empty")
+	}
 	if cfg.History.Include.Period != 365 {
 		t.Errorf("Period = %d, want 365", cfg.History.Include.Period)
 	}
@@ -25,6 +28,48 @@ func TestNewDefaultConfig(t *testing.T) {
 	}
 	if cfg.UI.Density != "spacious" {
 		t.Errorf("Density = %q, want %q", cfg.UI.Density, "spacious")
+	}
+
+	// Forbidden paths must include critical system dirs
+	forbiddenSet := make(map[string]bool)
+	for _, p := range cfg.Core.Trash.ForbiddenPaths {
+		forbiddenSet[p] = true
+	}
+	for _, p := range []string{"/", "/etc", "/usr", "/var", "/bin", "/sbin"} {
+		if !forbiddenSet[p] {
+			t.Errorf("ForbiddenPaths missing critical path %q", p)
+		}
+	}
+
+	// PermanentDelete should be disabled by default
+	if cfg.Core.PermanentDelete.Enable {
+		t.Error("PermanentDelete.Enable should be false by default")
+	}
+
+	// Restore defaults
+	if !cfg.Core.Restore.Confirm {
+		t.Error("Restore.Confirm should be true by default")
+	}
+
+	// Logging rotation defaults
+	if cfg.Logging.Rotation.MaxSize != "10MB" {
+		t.Errorf("Rotation.MaxSize = %q, want %q", cfg.Logging.Rotation.MaxSize, "10MB")
+	}
+	if cfg.Logging.Rotation.MaxFiles != 3 {
+		t.Errorf("Rotation.MaxFiles = %d, want 3", cfg.Logging.Rotation.MaxFiles)
+	}
+
+	// Preview defaults
+	if !cfg.UI.Preview.SyntaxHighlight {
+		t.Error("Preview.SyntaxHighlight should be true by default")
+	}
+	if cfg.UI.Paginator != "dots" {
+		t.Errorf("UI.Paginator = %q, want %q", cfg.UI.Paginator, "dots")
+	}
+
+	// History exclude defaults
+	if cfg.History.Exclude.Size.Max != "10GB" {
+		t.Errorf("History.Exclude.Size.Max = %q, want %q", cfg.History.Exclude.Size.Max, "10GB")
 	}
 }
 

--- a/internal/trash/legacy/storage_test.go
+++ b/internal/trash/legacy/storage_test.go
@@ -1,0 +1,290 @@
+package legacy
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/babarot/gomi/internal/config"
+	"github.com/babarot/gomi/internal/trash"
+)
+
+func newTestConfig(dir string) trash.Config {
+	return trash.Config{
+		GomiDir:  dir,
+		Strategy: trash.StrategyLegacy,
+		History:  config.History{},
+		RunID:    "test-run",
+	}
+}
+
+func TestNewStorage(t *testing.T) {
+	dir := t.TempDir()
+	cfg := newTestConfig(dir)
+
+	s, err := NewStorage(cfg)
+	if err != nil {
+		t.Fatalf("NewStorage() error = %v", err)
+	}
+	if s == nil {
+		t.Fatal("NewStorage() returned nil")
+	}
+
+	// Check info
+	info := s.Info()
+	if info.Type != trash.StorageTypeLegacy {
+		t.Errorf("Type = %v, want StorageTypeLegacy", info.Type)
+	}
+	if !info.Available {
+		t.Error("Available should be true")
+	}
+	if info.Location != trash.LocationHome {
+		t.Errorf("Location = %v, want LocationHome", info.Location)
+	}
+}
+
+func TestStorage_PutAndList(t *testing.T) {
+	dir := t.TempDir()
+	cfg := newTestConfig(dir)
+
+	s, err := NewStorage(cfg)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Create a file to trash
+	srcDir := t.TempDir()
+	srcFile := filepath.Join(srcDir, "test.txt")
+	if err := os.WriteFile(srcFile, []byte("hello"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	// Put it in trash
+	if err := s.Put(srcFile); err != nil {
+		t.Fatalf("Put() error = %v", err)
+	}
+
+	// Original should be gone
+	if _, err := os.Stat(srcFile); !os.IsNotExist(err) {
+		t.Error("original file should have been moved")
+	}
+
+	// List should return the file
+	files, err := s.List()
+	if err != nil {
+		t.Fatalf("List() error = %v", err)
+	}
+	if len(files) != 1 {
+		t.Fatalf("List() returned %d files, want 1", len(files))
+	}
+	if files[0].Name != "test.txt" {
+		t.Errorf("Name = %q, want %q", files[0].Name, "test.txt")
+	}
+	if files[0].OriginalPath != srcFile {
+		t.Errorf("OriginalPath = %q, want %q", files[0].OriginalPath, srcFile)
+	}
+}
+
+func TestStorage_Restore(t *testing.T) {
+	dir := t.TempDir()
+	cfg := newTestConfig(dir)
+
+	s, err := NewStorage(cfg)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Create and trash a file
+	srcDir := t.TempDir()
+	srcFile := filepath.Join(srcDir, "restore_me.txt")
+	content := []byte("restore this")
+	if err := os.WriteFile(srcFile, content, 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := s.Put(srcFile); err != nil {
+		t.Fatal(err)
+	}
+
+	// Get the trashed file
+	files, err := s.List()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(files) != 1 {
+		t.Fatalf("expected 1 file, got %d", len(files))
+	}
+
+	// Restore it
+	if err := s.Restore(files[0], srcFile); err != nil {
+		t.Fatalf("Restore() error = %v", err)
+	}
+
+	// File should be back
+	data, err := os.ReadFile(srcFile)
+	if err != nil {
+		t.Fatalf("restored file not found: %v", err)
+	}
+	if string(data) != string(content) {
+		t.Errorf("restored content = %q, want %q", string(data), string(content))
+	}
+
+	// Should be removed from trash listing
+	files, err = s.List()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(files) != 0 {
+		t.Errorf("List() returned %d files after restore, want 0", len(files))
+	}
+}
+
+func TestStorage_Remove(t *testing.T) {
+	dir := t.TempDir()
+	cfg := newTestConfig(dir)
+
+	s, err := NewStorage(cfg)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Create and trash a file
+	srcDir := t.TempDir()
+	srcFile := filepath.Join(srcDir, "delete_me.txt")
+	if err := os.WriteFile(srcFile, []byte("bye"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := s.Put(srcFile); err != nil {
+		t.Fatal(err)
+	}
+
+	files, err := s.List()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(files) != 1 {
+		t.Fatalf("expected 1 file, got %d", len(files))
+	}
+
+	// Remove permanently
+	if err := s.Remove(files[0]); err != nil {
+		t.Fatalf("Remove() error = %v", err)
+	}
+
+	// File should be gone from trash
+	if _, err := os.Stat(files[0].TrashPath); !os.IsNotExist(err) {
+		t.Error("trash file should have been removed")
+	}
+
+	// Should be removed from listing
+	files, err = s.List()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(files) != 0 {
+		t.Errorf("List() returned %d files after remove, want 0", len(files))
+	}
+}
+
+func TestStorage_PutDirectory(t *testing.T) {
+	dir := t.TempDir()
+	cfg := newTestConfig(dir)
+
+	s, err := NewStorage(cfg)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Create a directory with files
+	srcDir := t.TempDir()
+	testDir := filepath.Join(srcDir, "mydir")
+	os.MkdirAll(filepath.Join(testDir, "sub"), 0755)
+	os.WriteFile(filepath.Join(testDir, "a.txt"), []byte("a"), 0644)
+	os.WriteFile(filepath.Join(testDir, "sub", "b.txt"), []byte("b"), 0644)
+
+	if err := s.Put(testDir); err != nil {
+		t.Fatalf("Put(dir) error = %v", err)
+	}
+
+	if _, err := os.Stat(testDir); !os.IsNotExist(err) {
+		t.Error("original directory should have been moved")
+	}
+
+	files, err := s.List()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(files) != 1 {
+		t.Fatalf("expected 1 entry, got %d", len(files))
+	}
+	if files[0].Name != "mydir" {
+		t.Errorf("Name = %q, want %q", files[0].Name, "mydir")
+	}
+}
+
+func TestStorage_RestoreToCustomDst(t *testing.T) {
+	dir := t.TempDir()
+	cfg := newTestConfig(dir)
+
+	s, err := NewStorage(cfg)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Create and trash a file
+	srcDir := t.TempDir()
+	srcFile := filepath.Join(srcDir, "original.txt")
+	if err := os.WriteFile(srcFile, []byte("data"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := s.Put(srcFile); err != nil {
+		t.Fatal(err)
+	}
+
+	files, _ := s.List()
+
+	// Restore to custom destination
+	customDst := filepath.Join(t.TempDir(), "custom", "restored.txt")
+	if err := s.Restore(files[0], customDst); err != nil {
+		t.Fatalf("Restore() to custom dst error = %v", err)
+	}
+
+	data, err := os.ReadFile(customDst)
+	if err != nil {
+		t.Fatalf("custom dst file not found: %v", err)
+	}
+	if string(data) != "data" {
+		t.Errorf("content = %q, want %q", string(data), "data")
+	}
+}
+
+func TestStorage_PutMultipleFiles(t *testing.T) {
+	dir := t.TempDir()
+	cfg := newTestConfig(dir)
+
+	s, err := NewStorage(cfg)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	srcDir := t.TempDir()
+	for _, name := range []string{"a.txt", "b.txt", "c.txt"} {
+		os.WriteFile(filepath.Join(srcDir, name), []byte(name), 0644)
+	}
+
+	for _, name := range []string{"a.txt", "b.txt", "c.txt"} {
+		if err := s.Put(filepath.Join(srcDir, name)); err != nil {
+			t.Fatalf("Put(%s) error = %v", name, err)
+		}
+	}
+
+	files, err := s.List()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(files) != 3 {
+		t.Errorf("List() returned %d files, want 3", len(files))
+	}
+}

--- a/internal/trash/xdg/mountpoint_test.go
+++ b/internal/trash/xdg/mountpoint_test.go
@@ -1,0 +1,137 @@
+//go:build !windows
+
+package xdg
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestIsOnSameDevice(t *testing.T) {
+	dir := t.TempDir()
+
+	fileA := filepath.Join(dir, "a.txt")
+	fileB := filepath.Join(dir, "b.txt")
+	os.WriteFile(fileA, []byte("a"), 0644)
+	os.WriteFile(fileB, []byte("b"), 0644)
+
+	same, err := isOnSameDevice(fileA, fileB)
+	if err != nil {
+		t.Fatalf("isOnSameDevice() error = %v", err)
+	}
+	if !same {
+		t.Error("files in same tmpdir should be on same device")
+	}
+}
+
+func TestIsOnSameDevice_NonExistent(t *testing.T) {
+	_, err := isOnSameDevice("/nonexistent/path1", "/nonexistent/path2")
+	if err == nil {
+		t.Error("expected error for non-existent paths")
+	}
+}
+
+func TestIsOnSameDevice_WithSymlink(t *testing.T) {
+	dir := t.TempDir()
+	real := filepath.Join(dir, "real.txt")
+	link := filepath.Join(dir, "link.txt")
+
+	os.WriteFile(real, []byte("data"), 0644)
+	os.Symlink(real, link)
+
+	same, err := isOnSameDevice(real, link)
+	if err != nil {
+		t.Fatalf("isOnSameDevice() error = %v", err)
+	}
+	if !same {
+		t.Error("symlink and target should be on same device")
+	}
+}
+
+func TestIsValidExternalTrash_NotExists(t *testing.T) {
+	if isValidExternalTrash("/nonexistent/path") {
+		t.Error("non-existent path should not be valid")
+	}
+}
+
+func TestIsValidExternalTrash_RegularFile(t *testing.T) {
+	dir := t.TempDir()
+	file := filepath.Join(dir, "notadir")
+	os.WriteFile(file, []byte("x"), 0644)
+
+	if isValidExternalTrash(file) {
+		t.Error("regular file should not be valid external trash")
+	}
+}
+
+func TestIsValidExternalTrash_ValidDir(t *testing.T) {
+	dir := t.TempDir()
+	trashDir := filepath.Join(dir, ".Trash-1000")
+	os.MkdirAll(filepath.Join(trashDir, "files"), 0700)
+	os.MkdirAll(filepath.Join(trashDir, "info"), 0700)
+
+	if !isValidExternalTrash(trashDir) {
+		t.Error("properly structured trash dir should be valid")
+	}
+}
+
+func TestIsValidExternalTrash_Symlink(t *testing.T) {
+	dir := t.TempDir()
+	realDir := filepath.Join(dir, "real")
+	os.MkdirAll(filepath.Join(realDir, "files"), 0700)
+	os.MkdirAll(filepath.Join(realDir, "info"), 0700)
+
+	linkDir := filepath.Join(dir, "link")
+	os.Symlink(realDir, linkDir)
+
+	if isValidExternalTrash(linkDir) {
+		t.Error("symlink should not be valid external trash")
+	}
+}
+
+func TestCreateTrashDir(t *testing.T) {
+	dir := t.TempDir()
+	trashDir := filepath.Join(dir, "newtrash")
+
+	if err := createTrashDir(trashDir); err != nil {
+		t.Fatalf("createTrashDir() error = %v", err)
+	}
+
+	for _, sub := range []string{"files", "info"} {
+		subPath := filepath.Join(trashDir, sub)
+		fi, err := os.Stat(subPath)
+		if err != nil {
+			t.Errorf("subdirectory %q not created: %v", sub, err)
+			continue
+		}
+		if !fi.IsDir() {
+			t.Errorf("%q is not a directory", sub)
+		}
+		if fi.Mode().Perm() != 0700 {
+			t.Errorf("%q permissions = %o, want 0700", sub, fi.Mode().Perm())
+		}
+	}
+}
+
+func TestGetMountPoints(t *testing.T) {
+	points, err := getMountPoints()
+	if err != nil {
+		t.Fatalf("getMountPoints() error = %v", err)
+	}
+	if len(points) == 0 {
+		t.Error("getMountPoints() returned empty list")
+	}
+
+	// Root should always be present
+	var hasRoot bool
+	for _, p := range points {
+		if p == "/" {
+			hasRoot = true
+			break
+		}
+	}
+	if !hasRoot {
+		t.Error("mount points should include /")
+	}
+}

--- a/internal/trash/xdg/storage_test.go
+++ b/internal/trash/xdg/storage_test.go
@@ -1,0 +1,384 @@
+package xdg
+
+import (
+	"os"
+	"path/filepath"
+	"runtime"
+	"testing"
+	"time"
+
+	"github.com/babarot/gomi/internal/config"
+	"github.com/babarot/gomi/internal/trash"
+)
+
+func newTestStorage(t *testing.T) (trash.Storage, string) {
+	t.Helper()
+
+	if runtime.GOOS == "windows" {
+		t.Skip("XDG trash is not used on Windows")
+	}
+
+	// Use a temp dir as XDG_DATA_HOME so we don't touch real trash
+	dataDir := t.TempDir()
+	t.Setenv("XDG_DATA_HOME", dataDir)
+
+	cfg := trash.Config{
+		Strategy:       trash.StrategyXDG,
+		HomeFallback:   true,
+		ForceHomeTrash: true, // skip external trash scan
+		History:        config.History{},
+	}
+
+	s, err := NewStorage(cfg)
+	if err != nil {
+		t.Fatalf("NewStorage() error = %v", err)
+	}
+
+	return s, dataDir
+}
+
+func TestNewStorage_CreatesDirectories(t *testing.T) {
+	s, dataDir := newTestStorage(t)
+	_ = s
+
+	trashRoot := filepath.Join(dataDir, "Trash")
+	for _, sub := range []string{"files", "info"} {
+		dir := filepath.Join(trashRoot, sub)
+		fi, err := os.Stat(dir)
+		if err != nil {
+			t.Errorf("directory %q not created: %v", sub, err)
+			continue
+		}
+		if !fi.IsDir() {
+			t.Errorf("%q is not a directory", sub)
+		}
+	}
+}
+
+func TestStorage_Info(t *testing.T) {
+	s, dataDir := newTestStorage(t)
+
+	info := s.Info()
+	if info.Type != trash.StorageTypeXDG {
+		t.Errorf("Type = %v, want StorageTypeXDG", info.Type)
+	}
+	if !info.Available {
+		t.Error("Available should be true")
+	}
+	wantRoot := filepath.Join(dataDir, "Trash")
+	if len(info.Trashes) == 0 || info.Trashes[0] != wantRoot {
+		t.Errorf("Trashes = %v, want [%s]", info.Trashes, wantRoot)
+	}
+}
+
+func TestStorage_PutAndList(t *testing.T) {
+	s, _ := newTestStorage(t)
+
+	// Create a file to trash
+	srcDir := t.TempDir()
+	srcFile := filepath.Join(srcDir, "hello.txt")
+	if err := os.WriteFile(srcFile, []byte("hello"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := s.Put(srcFile); err != nil {
+		t.Fatalf("Put() error = %v", err)
+	}
+
+	// Original should be gone
+	if _, err := os.Stat(srcFile); !os.IsNotExist(err) {
+		t.Error("original file should have been removed")
+	}
+
+	files, err := s.List()
+	if err != nil {
+		t.Fatalf("List() error = %v", err)
+	}
+	if len(files) != 1 {
+		t.Fatalf("List() returned %d files, want 1", len(files))
+	}
+	if files[0].Name != "hello.txt" {
+		t.Errorf("Name = %q, want %q", files[0].Name, "hello.txt")
+	}
+	if files[0].OriginalPath != srcFile {
+		t.Errorf("OriginalPath = %q, want %q", files[0].OriginalPath, srcFile)
+	}
+}
+
+func TestStorage_Put_CreatesTrashInfo(t *testing.T) {
+	s, dataDir := newTestStorage(t)
+
+	srcDir := t.TempDir()
+	srcFile := filepath.Join(srcDir, "check_info.txt")
+	os.WriteFile(srcFile, []byte("data"), 0644)
+
+	if err := s.Put(srcFile); err != nil {
+		t.Fatal(err)
+	}
+
+	// Verify .trashinfo file exists
+	infoDir := filepath.Join(dataDir, "Trash", "info")
+	entries, err := os.ReadDir(infoDir)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var found bool
+	for _, e := range entries {
+		if filepath.Ext(e.Name()) == ".trashinfo" {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Error("no .trashinfo file created")
+	}
+}
+
+func TestStorage_Put_CollisionHandling(t *testing.T) {
+	s, _ := newTestStorage(t)
+
+	// Trash two files with the same name from different directories
+	for i := 0; i < 2; i++ {
+		srcDir := t.TempDir()
+		srcFile := filepath.Join(srcDir, "dup.txt")
+		os.WriteFile(srcFile, []byte("content"), 0644)
+
+		if err := s.Put(srcFile); err != nil {
+			t.Fatalf("Put() #%d error = %v", i, err)
+		}
+	}
+
+	files, err := s.List()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(files) != 2 {
+		t.Errorf("List() returned %d files, want 2 (collision should create unique names)", len(files))
+	}
+}
+
+func TestStorage_Restore(t *testing.T) {
+	s, _ := newTestStorage(t)
+
+	srcDir := t.TempDir()
+	srcFile := filepath.Join(srcDir, "restore_me.txt")
+	content := []byte("restore this")
+	os.WriteFile(srcFile, content, 0644)
+
+	if err := s.Put(srcFile); err != nil {
+		t.Fatal(err)
+	}
+
+	files, err := s.List()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(files) != 1 {
+		t.Fatalf("expected 1 file, got %d", len(files))
+	}
+
+	// Restore to original location
+	if err := s.Restore(files[0], srcFile); err != nil {
+		t.Fatalf("Restore() error = %v", err)
+	}
+
+	data, err := os.ReadFile(srcFile)
+	if err != nil {
+		t.Fatalf("restored file not found: %v", err)
+	}
+	if string(data) != string(content) {
+		t.Errorf("content = %q, want %q", string(data), string(content))
+	}
+
+	// Trash should be empty now
+	files, err = s.List()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(files) != 0 {
+		t.Errorf("List() returned %d after restore, want 0", len(files))
+	}
+}
+
+func TestStorage_Restore_CustomDst(t *testing.T) {
+	s, _ := newTestStorage(t)
+
+	srcDir := t.TempDir()
+	srcFile := filepath.Join(srcDir, "original.txt")
+	os.WriteFile(srcFile, []byte("data"), 0644)
+
+	if err := s.Put(srcFile); err != nil {
+		t.Fatal(err)
+	}
+
+	files, _ := s.List()
+	customDst := filepath.Join(t.TempDir(), "subdir", "restored.txt")
+
+	if err := s.Restore(files[0], customDst); err != nil {
+		t.Fatalf("Restore() to custom dst error = %v", err)
+	}
+
+	data, err := os.ReadFile(customDst)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(data) != "data" {
+		t.Errorf("content = %q, want %q", string(data), "data")
+	}
+}
+
+func TestStorage_Remove(t *testing.T) {
+	s, _ := newTestStorage(t)
+
+	srcDir := t.TempDir()
+	srcFile := filepath.Join(srcDir, "delete_me.txt")
+	os.WriteFile(srcFile, []byte("bye"), 0644)
+
+	if err := s.Put(srcFile); err != nil {
+		t.Fatal(err)
+	}
+
+	files, err := s.List()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(files) != 1 {
+		t.Fatalf("expected 1 file, got %d", len(files))
+	}
+
+	trashPath := files[0].TrashPath
+
+	if err := s.Remove(files[0]); err != nil {
+		t.Fatalf("Remove() error = %v", err)
+	}
+
+	// File should be gone from trash
+	if _, err := os.Stat(trashPath); !os.IsNotExist(err) {
+		t.Error("trash file should have been removed")
+	}
+
+	// Should be empty
+	files, err = s.List()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(files) != 0 {
+		t.Errorf("List() returned %d after remove, want 0", len(files))
+	}
+}
+
+func TestStorage_PutDirectory(t *testing.T) {
+	s, _ := newTestStorage(t)
+
+	srcDir := t.TempDir()
+	testDir := filepath.Join(srcDir, "mydir")
+	os.MkdirAll(filepath.Join(testDir, "sub"), 0755)
+	os.WriteFile(filepath.Join(testDir, "a.txt"), []byte("a"), 0644)
+	os.WriteFile(filepath.Join(testDir, "sub", "b.txt"), []byte("b"), 0644)
+
+	if err := s.Put(testDir); err != nil {
+		t.Fatalf("Put(dir) error = %v", err)
+	}
+
+	if _, err := os.Stat(testDir); !os.IsNotExist(err) {
+		t.Error("original directory should have been removed")
+	}
+
+	files, err := s.List()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(files) != 1 {
+		t.Fatalf("expected 1 entry, got %d", len(files))
+	}
+	if files[0].Name != "mydir" {
+		t.Errorf("Name = %q, want %q", files[0].Name, "mydir")
+	}
+	if !files[0].IsDir {
+		t.Error("IsDir should be true")
+	}
+}
+
+func TestStorage_List_Empty(t *testing.T) {
+	s, _ := newTestStorage(t)
+
+	files, err := s.List()
+	if err != nil {
+		t.Fatalf("List() error = %v", err)
+	}
+	if len(files) != 0 {
+		t.Errorf("List() returned %d files, want 0", len(files))
+	}
+}
+
+func TestStorage_List_SkipsInvalidInfo(t *testing.T) {
+	s, dataDir := newTestStorage(t)
+
+	trashRoot := filepath.Join(dataDir, "Trash")
+
+	// Create a file in files/ without a matching .trashinfo
+	os.WriteFile(filepath.Join(trashRoot, "files", "orphan.txt"), []byte("orphan"), 0644)
+
+	files, err := s.List()
+	if err != nil {
+		t.Fatalf("List() error = %v", err)
+	}
+	// Should skip orphan (no valid .trashinfo)
+	if len(files) != 0 {
+		t.Errorf("List() returned %d files, want 0 (orphan should be skipped)", len(files))
+	}
+}
+
+func TestTrashInfo_Save_And_Load(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("Unix-specific test")
+	}
+
+	dir := t.TempDir()
+	infoPath := filepath.Join(dir, "test.trashinfo")
+
+	info := &TrashInfo{
+		Path:         "/home/user/test file.txt",
+		DeletionDate: fixedTime(),
+	}
+
+	if err := info.Save(infoPath); err != nil {
+		t.Fatalf("Save() error = %v", err)
+	}
+
+	loaded, err := loadTrashInfo(infoPath)
+	if err != nil {
+		t.Fatalf("loadTrashInfo() error = %v", err)
+	}
+
+	if loaded.Path != info.Path {
+		t.Errorf("Path = %q, want %q", loaded.Path, info.Path)
+	}
+	if !loaded.DeletionDate.Equal(info.DeletionDate) {
+		t.Errorf("DeletionDate = %v, want %v", loaded.DeletionDate, info.DeletionDate)
+	}
+}
+
+func TestTrashInfo_Save_NoOverwrite(t *testing.T) {
+	dir := t.TempDir()
+	infoPath := filepath.Join(dir, "existing.trashinfo")
+
+	// Create an existing file
+	os.WriteFile(infoPath, []byte("existing"), 0644)
+
+	info := &TrashInfo{
+		Path:         "/tmp/file",
+		DeletionDate: fixedTime(),
+	}
+
+	// Save should fail because file already exists (O_EXCL)
+	err := info.Save(infoPath)
+	if err == nil {
+		t.Error("Save() should fail when file already exists")
+	}
+}
+
+func fixedTime() time.Time {
+	return time.Date(2024, 6, 15, 10, 30, 0, 0, time.Local)
+}

--- a/internal/ui/components_test.go
+++ b/internal/ui/components_test.go
@@ -1,0 +1,50 @@
+package ui
+
+import "testing"
+
+func TestOnlySpecialChars(t *testing.T) {
+	tests := []struct {
+		input string
+		want  bool
+	}{
+		{"...", true},
+		{"---", true},
+		{"___", true},
+		{"._-", true},
+		{"", true}, // vacuously true - no non-special chars
+		{"a", false},
+		{".a", false},
+		{"file.txt", false},
+		{"-name-", false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.input, func(t *testing.T) {
+			if got := onlySpecialChars(tt.input); got != tt.want {
+				t.Errorf("onlySpecialChars(%q) = %v, want %v", tt.input, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestIsImageFile(t *testing.T) {
+	tests := []struct {
+		mimeType string
+		want     bool
+	}{
+		{"image/png", true},
+		{"image/jpeg", true},
+		{"image/gif", true},
+		{"text/plain", false},
+		{"application/json", false},
+		{"", false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.mimeType, func(t *testing.T) {
+			if got := isImageFile(tt.mimeType); got != tt.want {
+				t.Errorf("isImageFile(%q) = %v, want %v", tt.mimeType, got, tt.want)
+			}
+		})
+	}
+}

--- a/internal/ui/selection_manager_test.go
+++ b/internal/ui/selection_manager_test.go
@@ -1,0 +1,85 @@
+package ui
+
+import (
+	"testing"
+
+	"github.com/babarot/gomi/internal/trash"
+)
+
+func newTestFile(name string) File {
+	return File{File: &trash.File{Name: name, TrashPath: "/trash/" + name}}
+}
+
+func TestSelectionManager_Add(t *testing.T) {
+	sm := &SelectionManager{items: []File{}}
+
+	f1 := newTestFile("a.txt")
+	sm.Add(f1)
+	if len(sm.items) != 1 {
+		t.Fatalf("expected 1 item, got %d", len(sm.items))
+	}
+
+	// Adding duplicate should be no-op
+	sm.Add(f1)
+	if len(sm.items) != 1 {
+		t.Errorf("expected 1 item after duplicate add, got %d", len(sm.items))
+	}
+}
+
+func TestSelectionManager_Remove(t *testing.T) {
+	sm := &SelectionManager{items: []File{}}
+
+	f1 := newTestFile("a.txt")
+	f2 := newTestFile("b.txt")
+	sm.Add(f1)
+	sm.Add(f2)
+
+	sm.Remove(f1)
+	if len(sm.items) != 1 {
+		t.Fatalf("expected 1 item after remove, got %d", len(sm.items))
+	}
+	if sm.items[0].Name != "b.txt" {
+		t.Errorf("remaining item = %q, want %q", sm.items[0].Name, "b.txt")
+	}
+
+	// Remove non-existent should be no-op
+	sm.Remove(newTestFile("nonexistent.txt"))
+	if len(sm.items) != 1 {
+		t.Errorf("expected 1 item after remove non-existent, got %d", len(sm.items))
+	}
+}
+
+func TestSelectionManager_Contains(t *testing.T) {
+	sm := &SelectionManager{items: []File{}}
+
+	f1 := newTestFile("a.txt")
+	if sm.Contains(f1) {
+		t.Error("should not contain f1 before adding")
+	}
+
+	sm.Add(f1)
+	if !sm.Contains(f1) {
+		t.Error("should contain f1 after adding")
+	}
+}
+
+func TestSelectionManager_IndexOf(t *testing.T) {
+	sm := &SelectionManager{items: []File{}}
+
+	f1 := newTestFile("a.txt")
+	f2 := newTestFile("b.txt")
+	sm.Add(f1)
+	sm.Add(f2)
+
+	if idx := sm.IndexOf(f1); idx != 0 {
+		t.Errorf("IndexOf(f1) = %d, want 0", idx)
+	}
+	if idx := sm.IndexOf(f2); idx != 1 {
+		t.Errorf("IndexOf(f2) = %d, want 1", idx)
+	}
+
+	missing := newTestFile("missing.txt")
+	if idx := sm.IndexOf(missing); idx != -1 {
+		t.Errorf("IndexOf(missing) = %d, want -1", idx)
+	}
+}

--- a/internal/ui/state_test.go
+++ b/internal/ui/state_test.go
@@ -1,0 +1,225 @@
+package ui
+
+import (
+	"testing"
+	"time"
+)
+
+func TestNewViewState(t *testing.T) {
+	s := NewViewState()
+	if s.current != ListView {
+		t.Errorf("current = %v, want ListView", s.current)
+	}
+	if s.previous != ListView {
+		t.Errorf("previous = %v, want ListView", s.previous)
+	}
+	if s.detail.dateFormat != DateFormatRelative {
+		t.Errorf("dateFormat = %v, want DateFormatRelative", s.detail.dateFormat)
+	}
+	if !s.detail.showOrigin {
+		t.Error("showOrigin should be true")
+	}
+	if !s.preview.available {
+		t.Error("preview.available should be true")
+	}
+	if s.confirmation.state != ConfirmStateYesNo {
+		t.Errorf("confirmation.state = %v, want ConfirmStateYesNo", s.confirmation.state)
+	}
+}
+
+func TestViewState_SetView(t *testing.T) {
+	s := NewViewState()
+
+	s.SetView(DetailView)
+	if s.current != DetailView {
+		t.Errorf("current = %v, want DetailView", s.current)
+	}
+	if s.previous != ListView {
+		t.Errorf("previous = %v, want ListView", s.previous)
+	}
+
+	s.SetView(ConfirmView)
+	if s.current != ConfirmView {
+		t.Errorf("current = %v, want ConfirmView", s.current)
+	}
+	if s.previous != DetailView {
+		t.Errorf("previous = %v, want DetailView", s.previous)
+	}
+}
+
+func TestViewState_ToggleDateFormat(t *testing.T) {
+	s := NewViewState()
+
+	// Default is Relative
+	s.ToggleDateFormat()
+	if s.detail.dateFormat != DateFormatAbsolute {
+		t.Errorf("dateFormat = %v, want Absolute after first toggle", s.detail.dateFormat)
+	}
+
+	s.ToggleDateFormat()
+	if s.detail.dateFormat != DateFormatRelative {
+		t.Errorf("dateFormat = %v, want Relative after second toggle", s.detail.dateFormat)
+	}
+}
+
+func TestViewState_ToggleOriginPath(t *testing.T) {
+	s := NewViewState()
+
+	s.ToggleOriginPath()
+	if s.detail.showOrigin {
+		t.Error("showOrigin should be false after toggle")
+	}
+
+	s.ToggleOriginPath()
+	if !s.detail.showOrigin {
+		t.Error("showOrigin should be true after second toggle")
+	}
+}
+
+func TestViewState_FormatDate(t *testing.T) {
+	s := NewViewState()
+	now := time.Now()
+
+	// Relative format (default)
+	relative := s.FormatDate(now)
+	if relative == "" {
+		t.Error("relative format should not be empty")
+	}
+
+	// Absolute format
+	s.ToggleDateFormat()
+	absolute := s.FormatDate(now)
+	if absolute == "" {
+		t.Error("absolute format should not be empty")
+	}
+	// Should contain date components
+	expected := now.Format(time.DateTime)
+	if absolute != expected {
+		t.Errorf("absolute = %q, want %q", absolute, expected)
+	}
+}
+
+func TestViewState_SetConfirmState(t *testing.T) {
+	s := NewViewState()
+
+	files := []File{{}, {}}
+	s.SetConfirmState(ConfirmStateTypeYES, files)
+
+	if s.confirmation.state != ConfirmStateTypeYES {
+		t.Errorf("state = %v, want ConfirmStateTypeYES", s.confirmation.state)
+	}
+	if len(s.confirmation.files) != 2 {
+		t.Errorf("files = %d, want 2", len(s.confirmation.files))
+	}
+	if s.confirmation.yesInput != "" {
+		t.Error("yesInput should be reset")
+	}
+}
+
+func TestViewState_UpdateYesInput(t *testing.T) {
+	s := NewViewState()
+
+	// Correct sequence: Y, E, S
+	s.UpdateYesInput("Y")
+	if s.confirmation.yesInput != "Y" {
+		t.Errorf("yesInput = %q, want %q", s.confirmation.yesInput, "Y")
+	}
+
+	s.UpdateYesInput("E")
+	if s.confirmation.yesInput != "YE" {
+		t.Errorf("yesInput = %q, want %q", s.confirmation.yesInput, "YE")
+	}
+
+	s.UpdateYesInput("S")
+	if s.confirmation.yesInput != "YES" {
+		t.Errorf("yesInput = %q, want %q", s.confirmation.yesInput, "YES")
+	}
+
+	if !s.IsYesComplete() {
+		t.Error("should be complete after Y-E-S")
+	}
+}
+
+func TestViewState_UpdateYesInput_WrongChars(t *testing.T) {
+	s := NewViewState()
+
+	// Wrong first char
+	s.UpdateYesInput("y") // lowercase
+	if s.confirmation.yesInput != "" {
+		t.Errorf("yesInput = %q, want empty (lowercase y rejected)", s.confirmation.yesInput)
+	}
+
+	// Start correctly, then wrong
+	s.UpdateYesInput("Y")
+	s.UpdateYesInput("X") // wrong
+	if s.confirmation.yesInput != "Y" {
+		t.Errorf("yesInput = %q, want %q (wrong second char rejected)", s.confirmation.yesInput, "Y")
+	}
+}
+
+func TestViewState_BackspaceYesInput(t *testing.T) {
+	s := NewViewState()
+
+	s.UpdateYesInput("Y")
+	s.UpdateYesInput("E")
+	s.BackspaceYesInput()
+	if s.confirmation.yesInput != "Y" {
+		t.Errorf("yesInput = %q, want %q after backspace", s.confirmation.yesInput, "Y")
+	}
+
+	// Backspace on empty should be safe
+	s.BackspaceYesInput()
+	s.BackspaceYesInput() // now empty
+	s.BackspaceYesInput() // extra backspace on empty
+	if s.confirmation.yesInput != "" {
+		t.Errorf("yesInput = %q, want empty", s.confirmation.yesInput)
+	}
+}
+
+func TestViewState_ClearYesInput(t *testing.T) {
+	s := NewViewState()
+	s.UpdateYesInput("Y")
+	s.UpdateYesInput("E")
+	s.ClearYesInput()
+	if s.confirmation.yesInput != "" {
+		t.Error("yesInput should be empty after clear")
+	}
+}
+
+func TestViewState_IsYesComplete(t *testing.T) {
+	s := NewViewState()
+
+	if s.IsYesComplete() {
+		t.Error("should not be complete initially")
+	}
+
+	s.UpdateYesInput("Y")
+	if s.IsYesComplete() {
+		t.Error("should not be complete after only Y")
+	}
+
+	s.UpdateYesInput("E")
+	s.UpdateYesInput("S")
+	if !s.IsYesComplete() {
+		t.Error("should be complete after YES")
+	}
+}
+
+func TestViewType_String(t *testing.T) {
+	tests := []struct {
+		v    ViewType
+		want string
+	}{
+		{ListView, "list view"},
+		{DetailView, "detail view"},
+		{ConfirmView, "confirm view"},
+		{Quitting, "quit"},
+		{ViewType(99), "unknown"},
+	}
+
+	for _, tt := range tests {
+		if got := tt.v.String(); got != tt.want {
+			t.Errorf("ViewType(%d).String() = %q, want %q", tt.v, got, tt.want)
+		}
+	}
+}

--- a/internal/ui/update_test.go
+++ b/internal/ui/update_test.go
@@ -1,0 +1,315 @@
+package ui
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/babarot/gomi/internal/config"
+	"github.com/babarot/gomi/internal/trash"
+	"github.com/babarot/gomi/internal/ui/keys"
+	"github.com/babarot/gomi/internal/ui/styles"
+	"github.com/charmbracelet/bubbles/help"
+	"github.com/charmbracelet/bubbles/list"
+	"github.com/charmbracelet/bubbles/viewport"
+	tea "github.com/charmbracelet/bubbletea"
+)
+
+// newTestModel creates a minimal Model for testing Update logic
+func newTestModel() Model {
+	cfg := config.NewDefaultConfig()
+	km := keys.NewKeyMap(keys.KeyMapConfig{DeleteEnabled: true})
+
+	delegate := list.NewDefaultDelegate()
+	l := list.New(nil, delegate, 80, 40)
+	l.SetShowStatusBar(false)
+	l.SetShowTitle(false)
+	l.DisableQuitKeybindings()
+
+	return Model{
+		state:    NewViewState(),
+		keyMap:   km,
+		config:   cfg.UI,
+		list:     l,
+		viewport: viewport.Model{},
+		styles:   styles.New(cfg.UI),
+		help:     help.New(),
+	}
+}
+
+func TestUpdate_WindowSizeMsg(t *testing.T) {
+	m := newTestModel()
+
+	msg := tea.WindowSizeMsg{Width: 120, Height: 40}
+	updated, _ := m.Update(msg)
+	model := updated.(Model)
+
+	if model.list.Width() != 120 {
+		t.Errorf("list width = %d, want 120", model.list.Width())
+	}
+}
+
+func TestUpdate_ErrorMsg(t *testing.T) {
+	m := newTestModel()
+
+	msg := errorMsg{err: errors.New("test error")}
+	updated, cmd := m.Update(msg)
+	model := updated.(Model)
+
+	if model.state.current != Quitting {
+		t.Errorf("state = %v, want Quitting", model.state.current)
+	}
+	if model.err == nil {
+		t.Error("err should be set")
+	}
+	if cmd == nil {
+		t.Error("should return tea.Quit cmd")
+	}
+}
+
+func TestUpdate_FileListLoadedMsg(t *testing.T) {
+	m := newTestModel()
+
+	file := newTestFile("loaded.txt")
+	msg := FileListLoadedMsg{files: []list.Item{file}}
+	updated, _ := m.Update(msg)
+	model := updated.(Model)
+
+	items := model.list.Items()
+	if len(items) != 1 {
+		t.Errorf("items = %d, want 1", len(items))
+	}
+}
+
+func TestUpdate_FileListLoadedMsg_Error(t *testing.T) {
+	m := newTestModel()
+
+	msg := FileListLoadedMsg{err: errors.New("load failed")}
+	updated, cmd := m.Update(msg)
+	model := updated.(Model)
+
+	if model.err == nil {
+		t.Error("err should be set")
+	}
+	if cmd == nil {
+		t.Error("should return tea.Quit cmd")
+	}
+}
+
+func TestUpdate_ListView_Quit(t *testing.T) {
+	m := newTestModel()
+	m.state.SetView(ListView)
+
+	msg := tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("q")}
+	updated, cmd := m.Update(msg)
+	model := updated.(Model)
+
+	if model.state.current != Quitting {
+		t.Errorf("state = %v, want Quitting", model.state.current)
+	}
+	if cmd == nil {
+		t.Error("should return tea.Quit cmd")
+	}
+}
+
+func TestUpdate_ListView_CtrlC(t *testing.T) {
+	m := newTestModel()
+	m.state.SetView(ListView)
+
+	msg := tea.KeyMsg{Type: tea.KeyCtrlC}
+	updated, cmd := m.Update(msg)
+	model := updated.(Model)
+
+	if model.state.current != Quitting {
+		t.Errorf("state = %v, want Quitting", model.state.current)
+	}
+	if cmd == nil {
+		t.Error("should return tea.Quit cmd")
+	}
+}
+
+func TestUpdate_DetailView_EscReturnsToList(t *testing.T) {
+	m := newTestModel()
+	m.state.SetView(DetailView)
+
+	msg := tea.KeyMsg{Type: tea.KeyEsc}
+	updated, _ := m.Update(msg)
+	model := updated.(Model)
+
+	if model.state.current != ListView {
+		t.Errorf("state = %v, want ListView", model.state.current)
+	}
+}
+
+func TestUpdate_DetailView_Quit(t *testing.T) {
+	m := newTestModel()
+	m.state.SetView(DetailView)
+
+	msg := tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("q")}
+	updated, cmd := m.Update(msg)
+	model := updated.(Model)
+
+	if model.state.current != Quitting {
+		t.Errorf("state = %v, want Quitting", model.state.current)
+	}
+	if cmd == nil {
+		t.Error("should return tea.Quit cmd")
+	}
+}
+
+func TestUpdate_DetailView_AtSignToggles(t *testing.T) {
+	m := newTestModel()
+	m.state.SetView(DetailView)
+
+	// Initial state
+	initialDateFormat := m.state.detail.dateFormat
+	initialShowOrigin := m.state.detail.showOrigin
+
+	msg := tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("@")}
+	updated, _ := m.Update(msg)
+	model := updated.(Model)
+
+	if model.state.detail.dateFormat == initialDateFormat {
+		t.Error("date format should have toggled")
+	}
+	if model.state.detail.showOrigin == initialShowOrigin {
+		t.Error("showOrigin should have toggled")
+	}
+}
+
+func TestUpdate_ConfirmView_YesNo_No(t *testing.T) {
+	m := newTestModel()
+	// Reset global selection manager for test isolation
+	selectionManager = &SelectionManager{items: []File{}}
+
+	m.state.SetView(ConfirmView)
+	m.state.SetConfirmState(ConfirmStateYesNo, []File{})
+
+	msg := tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("n")}
+	updated, _ := m.Update(msg)
+	model := updated.(Model)
+
+	// Should go back to previous view
+	if model.state.current == ConfirmView {
+		t.Error("should have left ConfirmView after pressing 'n'")
+	}
+}
+
+func TestUpdate_ConfirmView_YesNo_Quit(t *testing.T) {
+	m := newTestModel()
+	selectionManager = &SelectionManager{items: []File{}}
+
+	m.state.SetView(ConfirmView)
+	m.state.SetConfirmState(ConfirmStateYesNo, []File{})
+
+	msg := tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("q")}
+	updated, cmd := m.Update(msg)
+	model := updated.(Model)
+
+	if model.state.current != Quitting {
+		t.Errorf("state = %v, want Quitting", model.state.current)
+	}
+	if cmd == nil {
+		t.Error("should return tea.Quit cmd")
+	}
+}
+
+func TestUpdate_ConfirmView_TypeYES_Backspace(t *testing.T) {
+	m := newTestModel()
+	selectionManager = &SelectionManager{items: []File{}}
+
+	m.state.SetView(ConfirmView)
+	m.state.SetConfirmState(ConfirmStateTypeYES, []File{})
+
+	// Type "Y"
+	msg := tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("Y")}
+	updated, _ := m.Update(msg)
+	m = updated.(Model)
+
+	if m.state.confirmation.yesInput != "Y" {
+		t.Errorf("yesInput = %q, want %q", m.state.confirmation.yesInput, "Y")
+	}
+
+	// Backspace
+	msg = tea.KeyMsg{Type: tea.KeyBackspace}
+	updated, _ = m.Update(msg)
+	m = updated.(Model)
+
+	if m.state.confirmation.yesInput != "" {
+		t.Errorf("yesInput = %q, want empty after backspace", m.state.confirmation.yesInput)
+	}
+}
+
+func TestUpdate_ConfirmView_TypeYES_Esc(t *testing.T) {
+	m := newTestModel()
+	selectionManager = &SelectionManager{items: []File{}}
+
+	m.state.SetView(ConfirmView)
+	m.state.SetConfirmState(ConfirmStateTypeYES, []File{})
+
+	msg := tea.KeyMsg{Type: tea.KeyEsc}
+	updated, _ := m.Update(msg)
+	model := updated.(Model)
+
+	if model.state.current == ConfirmView {
+		t.Error("esc should leave ConfirmView")
+	}
+}
+
+func TestUpdate_ListView_Enter_NoFiles(t *testing.T) {
+	m := newTestModel()
+	selectionManager = &SelectionManager{items: []File{}}
+	m.state.SetView(ListView)
+
+	// Add an item to the list so SelectedItem works
+	f := newTestFile("test.txt")
+	m.list.SetItems([]list.Item{f})
+
+	msg := tea.KeyMsg{Type: tea.KeyEnter}
+	updated, cmd := m.Update(msg)
+	model := updated.(Model)
+
+	// With no selection manager items, it should pick the current item
+	if len(model.choices) != 1 {
+		t.Errorf("choices = %d, want 1", len(model.choices))
+	}
+	if cmd == nil {
+		t.Error("should return tea.Quit cmd")
+	}
+}
+
+func TestUpdate_ListView_Enter_WithSelection(t *testing.T) {
+	m := newTestModel()
+
+	f1 := newTestFile("a.txt")
+	f2 := newTestFile("b.txt")
+	selectionManager = &SelectionManager{items: []File{f1, f2}}
+	m.state.SetView(ListView)
+	m.list.SetItems([]list.Item{f1, f2})
+
+	msg := tea.KeyMsg{Type: tea.KeyEnter}
+	updated, cmd := m.Update(msg)
+	model := updated.(Model)
+
+	if len(model.choices) != 2 {
+		t.Errorf("choices = %d, want 2", len(model.choices))
+	}
+	if cmd == nil {
+		t.Error("should return tea.Quit cmd")
+	}
+}
+
+func TestUpdate_ShowDetailMsg(t *testing.T) {
+	m := newTestModel()
+
+	file := File{File: &trash.File{Name: "detail.txt", TrashPath: "/trash/detail.txt"}}
+	msg := ShowDetailMsg{file: file}
+	updated, _ := m.Update(msg)
+	model := updated.(Model)
+
+	if model.state.current != DetailView {
+		t.Errorf("state = %v, want DetailView", model.state.current)
+	}
+	if model.detailFile.Name != "detail.txt" {
+		t.Errorf("detailFile.Name = %q, want %q", model.detailFile.Name, "detail.txt")
+	}
+}

--- a/internal/utils/debug/debug_test.go
+++ b/internal/utils/debug/debug_test.go
@@ -1,0 +1,89 @@
+package debug
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestShowExistingLogs(t *testing.T) {
+	dir := t.TempDir()
+	logPath := filepath.Join(dir, "test.log")
+
+	content := "line1\nline2\nline3\n"
+	os.WriteFile(logPath, []byte(content), 0644)
+
+	var buf bytes.Buffer
+	err := showExistingLogs(&buf, logPath)
+	if err != nil {
+		t.Fatalf("showExistingLogs() error = %v", err)
+	}
+
+	output := buf.String()
+	if !strings.Contains(output, "line1") {
+		t.Errorf("output missing line1, got %q", output)
+	}
+	if !strings.Contains(output, "line3") {
+		t.Errorf("output missing line3, got %q", output)
+	}
+}
+
+func TestShowExistingLogs_NonExistent(t *testing.T) {
+	var buf bytes.Buffer
+	err := showExistingLogs(&buf, "/nonexistent/debug.log")
+	if err == nil {
+		t.Fatal("expected error for non-existent file")
+	}
+	if err != ErrLogFileNotFound {
+		t.Errorf("error = %v, want ErrLogFileNotFound", err)
+	}
+}
+
+func TestShowExistingLogs_EmptyFile(t *testing.T) {
+	dir := t.TempDir()
+	logPath := filepath.Join(dir, "empty.log")
+	os.WriteFile(logPath, []byte(""), 0644)
+
+	var buf bytes.Buffer
+	err := showExistingLogs(&buf, logPath)
+	if err != nil {
+		t.Fatalf("showExistingLogs() error = %v", err)
+	}
+	if buf.Len() != 0 {
+		t.Errorf("expected empty output, got %q", buf.String())
+	}
+}
+
+func TestLogs_FullMode(t *testing.T) {
+	dir := t.TempDir()
+	logPath := filepath.Join(dir, "test.log")
+	os.WriteFile(logPath, []byte("hello\nworld\n"), 0644)
+
+	var buf bytes.Buffer
+	err := Logs(&buf, logPath, false)
+	if err != nil {
+		t.Fatalf("Logs(live=false) error = %v", err)
+	}
+	if !strings.Contains(buf.String(), "hello") {
+		t.Errorf("output missing 'hello', got %q", buf.String())
+	}
+}
+
+func TestLogs_NonExistent(t *testing.T) {
+	var buf bytes.Buffer
+	err := Logs(&buf, "/nonexistent/path.log", false)
+	if err != ErrLogFileNotFound {
+		t.Errorf("error = %v, want ErrLogFileNotFound", err)
+	}
+}
+
+func TestConstants(t *testing.T) {
+	if LiveMode != "live" {
+		t.Errorf("LiveMode = %q, want %q", LiveMode, "live")
+	}
+	if FullMode != "full" {
+		t.Errorf("FullMode = %q, want %q", FullMode, "full")
+	}
+}

--- a/internal/utils/fs/dir_test.go
+++ b/internal/utils/fs/dir_test.go
@@ -1,0 +1,110 @@
+package fs
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestDirSize_EmptyDir(t *testing.T) {
+	dir := createTempDir(t)
+
+	size, err := DirSize(dir)
+	if err != nil {
+		t.Fatalf("DirSize() error = %v", err)
+	}
+	if size != 0 {
+		t.Errorf("DirSize() = %d, want 0 for empty dir", size)
+	}
+}
+
+func TestDirSize_SingleFile(t *testing.T) {
+	dir := createTempDir(t)
+	content := "hello world"
+	createTestFile(t, filepath.Join(dir, "file.txt"), content)
+
+	size, err := DirSize(dir)
+	if err != nil {
+		t.Fatalf("DirSize() error = %v", err)
+	}
+	if size != int64(len(content)) {
+		t.Errorf("DirSize() = %d, want %d", size, len(content))
+	}
+}
+
+func TestDirSize_MultipleFiles(t *testing.T) {
+	dir := createTempDir(t)
+	createTestFile(t, filepath.Join(dir, "a.txt"), "aaa")
+	createTestFile(t, filepath.Join(dir, "b.txt"), "bbbbb")
+
+	size, err := DirSize(dir)
+	if err != nil {
+		t.Fatalf("DirSize() error = %v", err)
+	}
+	if size != 8 {
+		t.Errorf("DirSize() = %d, want 8", size)
+	}
+}
+
+func TestDirSize_NestedDirs(t *testing.T) {
+	dir := createTempDir(t)
+	sub := filepath.Join(dir, "sub")
+	if err := os.MkdirAll(sub, 0755); err != nil {
+		t.Fatal(err)
+	}
+	createTestFile(t, filepath.Join(dir, "top.txt"), "top")
+	createTestFile(t, filepath.Join(sub, "nested.txt"), "nested")
+
+	size, err := DirSize(dir)
+	if err != nil {
+		t.Fatalf("DirSize() error = %v", err)
+	}
+	expected := int64(len("top") + len("nested"))
+	if size != expected {
+		t.Errorf("DirSize() = %d, want %d", size, expected)
+	}
+}
+
+func TestDirSize_SymlinksSkipped(t *testing.T) {
+	dir := createTempDir(t)
+	content := "real file"
+	realFile := filepath.Join(dir, "real.txt")
+	createTestFile(t, realFile, content)
+
+	linkPath := filepath.Join(dir, "link.txt")
+	if err := os.Symlink(realFile, linkPath); err != nil {
+		t.Fatal(err)
+	}
+
+	size, err := DirSize(dir)
+	if err != nil {
+		t.Fatalf("DirSize() error = %v", err)
+	}
+	// Symlink should be skipped, so only real file counted
+	if size != int64(len(content)) {
+		t.Errorf("DirSize() = %d, want %d (symlink should be skipped)", size, len(content))
+	}
+}
+
+func TestDirSize_NonExistentPath(t *testing.T) {
+	_, err := DirSize("/nonexistent/path/that/does/not/exist")
+	if err == nil {
+		t.Fatal("DirSize() expected error for non-existent path, got nil")
+	}
+}
+
+func TestDirSize_RegularFile(t *testing.T) {
+	dir := createTempDir(t)
+	file := filepath.Join(dir, "single.txt")
+	content := "just a file"
+	createTestFile(t, file, content)
+
+	// DirSize should work on a single file too
+	size, err := DirSize(file)
+	if err != nil {
+		t.Fatalf("DirSize() error = %v", err)
+	}
+	if size != int64(len(content)) {
+		t.Errorf("DirSize() = %d, want %d", size, len(content))
+	}
+}

--- a/internal/utils/log/log_test.go
+++ b/internal/utils/log/log_test.go
@@ -41,16 +41,17 @@ func TestNew_AsDefault(t *testing.T) {
 	}
 }
 
-func TestNew_WithRotation(t *testing.T) {
+func TestNew_WithOptions(t *testing.T) {
 	Reset()
 	defer Reset()
 
-	dir := t.TempDir()
-	logPath := dir + "/test.log"
-
+	// Test New() with multiple options combined.
+	// Uses io.Discard to avoid file handle leaks on Windows.
 	logger, err := New(
-		UseOutputPath(logPath),
-		EnableRotation("1MB", 3),
+		UseOutput(io.Discard),
+		UseLevel(DebugLevel),
+		UseReportCaller(true),
+		UseReportTimestamp(true),
 	)
 	if err != nil {
 		t.Fatalf("New() error = %v", err)

--- a/internal/utils/log/log_test.go
+++ b/internal/utils/log/log_test.go
@@ -1,0 +1,81 @@
+package log
+
+import (
+	"io"
+	"testing"
+)
+
+func TestNew(t *testing.T) {
+	Reset()
+	defer Reset()
+
+	logger, err := New(
+		UseLevel(DebugLevel),
+		UseOutput(io.Discard),
+	)
+	if err != nil {
+		t.Fatalf("New() error = %v", err)
+	}
+	if logger == nil {
+		t.Fatal("New() returned nil logger")
+	}
+}
+
+func TestNew_AsDefault(t *testing.T) {
+	Reset()
+	defer Reset()
+
+	_, err := New(
+		UseLevel(InfoLevel),
+		UseOutput(io.Discard),
+		AsDefault(),
+	)
+	if err != nil {
+		t.Fatalf("New() error = %v", err)
+	}
+
+	// After AsDefault, Default() should return a non-nil logger
+	def := Default()
+	if def == nil {
+		t.Error("Default() should return non-nil after AsDefault()")
+	}
+}
+
+func TestNew_WithRotation(t *testing.T) {
+	Reset()
+	defer Reset()
+
+	dir := t.TempDir()
+	logPath := dir + "/test.log"
+
+	logger, err := New(
+		UseOutputPath(logPath),
+		EnableRotation("1MB", 3),
+	)
+	if err != nil {
+		t.Fatalf("New() error = %v", err)
+	}
+	if logger == nil {
+		t.Fatal("New() returned nil logger")
+	}
+}
+
+func TestDefault(t *testing.T) {
+	Reset()
+	defer Reset()
+
+	d := Default()
+	if d == nil {
+		t.Fatal("Default() returned nil")
+	}
+}
+
+func TestReset(t *testing.T) {
+	Reset()
+
+	// After reset, Default() should create a new logger
+	d := Default()
+	if d == nil {
+		t.Fatal("Default() returned nil after Reset()")
+	}
+}

--- a/internal/utils/log/options_test.go
+++ b/internal/utils/log/options_test.go
@@ -1,0 +1,166 @@
+package log
+
+import (
+	"bytes"
+	"io"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+func TestDefaultOptions(t *testing.T) {
+	o := DefaultOptions()
+	if o.Level != InfoLevel {
+		t.Errorf("Level = %v, want InfoLevel", o.Level)
+	}
+	if o.Writer != os.Stderr {
+		t.Error("Writer should default to os.Stderr")
+	}
+	if o.ReportCaller {
+		t.Error("ReportCaller should default to false")
+	}
+	if o.ReportTimestamp {
+		t.Error("ReportTimestamp should default to false")
+	}
+	if o.Styles == nil {
+		t.Error("Styles should not be nil")
+	}
+}
+
+func TestUseLevel(t *testing.T) {
+	o := DefaultOptions()
+	UseLevel(DebugLevel)(o)
+	if o.Level != DebugLevel {
+		t.Errorf("Level = %v, want DebugLevel", o.Level)
+	}
+}
+
+func TestUseOutput(t *testing.T) {
+	o := DefaultOptions()
+	var buf bytes.Buffer
+	UseOutput(&buf)(o)
+	if o.Writer != &buf {
+		t.Error("Writer not set correctly")
+	}
+}
+
+func TestUseOutputPath(t *testing.T) {
+	dir := t.TempDir()
+	logPath := filepath.Join(dir, "subdir", "test.log")
+
+	o := DefaultOptions()
+	UseOutputPath(logPath)(o)
+
+	if o.OutputFunc == nil {
+		t.Fatal("OutputFunc should be set")
+	}
+
+	w, err := o.OutputFunc()
+	if err != nil {
+		t.Fatalf("OutputFunc() error = %v", err)
+	}
+	if f, ok := w.(*os.File); ok {
+		f.Close()
+	}
+
+	// Directory should have been created
+	if _, err := os.Stat(filepath.Dir(logPath)); err != nil {
+		t.Errorf("log directory not created: %v", err)
+	}
+}
+
+func TestUseOutputPath_Empty(t *testing.T) {
+	o := DefaultOptions()
+	UseOutputPath("")(o)
+
+	w, err := o.OutputFunc()
+	if err != nil {
+		t.Fatalf("OutputFunc() error = %v", err)
+	}
+	if w != os.Stderr {
+		t.Error("empty path should return os.Stderr")
+	}
+}
+
+func TestEnableRotation(t *testing.T) {
+	t.Run("valid settings", func(t *testing.T) {
+		o := DefaultOptions()
+		EnableRotation("10MB", 3)(o)
+		if !o.RotationEnabled {
+			t.Error("RotationEnabled should be true")
+		}
+		if o.RotationMaxSize != "10MB" {
+			t.Errorf("RotationMaxSize = %q, want %q", o.RotationMaxSize, "10MB")
+		}
+		if o.RotationMaxFiles != 3 {
+			t.Errorf("RotationMaxFiles = %d, want 3", o.RotationMaxFiles)
+		}
+	})
+
+	t.Run("empty maxSize disables rotation", func(t *testing.T) {
+		o := DefaultOptions()
+		EnableRotation("", 3)(o)
+		if o.RotationEnabled {
+			t.Error("RotationEnabled should be false for empty maxSize")
+		}
+	})
+
+	t.Run("invalid maxSize disables rotation", func(t *testing.T) {
+		o := DefaultOptions()
+		EnableRotation("notasize", 3)(o)
+		if o.RotationEnabled {
+			t.Error("RotationEnabled should be false for invalid maxSize")
+		}
+	})
+}
+
+func TestUseReportCaller(t *testing.T) {
+	o := DefaultOptions()
+	UseReportCaller(true)(o)
+	if !o.ReportCaller {
+		t.Error("ReportCaller should be true")
+	}
+}
+
+func TestUseReportTimestamp(t *testing.T) {
+	o := DefaultOptions()
+	UseReportTimestamp(true)(o)
+	if !o.ReportTimestamp {
+		t.Error("ReportTimestamp should be true")
+	}
+}
+
+func TestUseTimeFormat(t *testing.T) {
+	o := DefaultOptions()
+	UseTimeFormat(time.Kitchen)(o)
+	if o.TimeFormat != time.Kitchen {
+		t.Errorf("TimeFormat = %q, want %q", o.TimeFormat, time.Kitchen)
+	}
+}
+
+func TestAsDefault(t *testing.T) {
+	o := DefaultOptions()
+	AsDefault()(o)
+	if !o.Default {
+		t.Error("Default should be true")
+	}
+}
+
+func TestApply(t *testing.T) {
+	o := DefaultOptions()
+	err := o.Apply(
+		UseLevel(WarnLevel),
+		UseReportCaller(true),
+		UseOutput(io.Discard),
+	)
+	if err != nil {
+		t.Fatalf("Apply() error = %v", err)
+	}
+	if o.Level != WarnLevel {
+		t.Errorf("Level = %v, want WarnLevel", o.Level)
+	}
+	if !o.ReportCaller {
+		t.Error("ReportCaller should be true")
+	}
+}

--- a/internal/utils/log/rotate_test.go
+++ b/internal/utils/log/rotate_test.go
@@ -1,0 +1,162 @@
+package log
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestNewRotateWriter(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "test.log")
+
+	rw, err := newRotateWriter(path, "1MB", 3)
+	if err != nil {
+		t.Fatalf("newRotateWriter() error = %v", err)
+	}
+	defer rw.Close()
+
+	// docker/go-units uses SI units: 1MB = 1,000,000
+	if rw.maxSize != 1000000 {
+		t.Errorf("maxSize = %d, want %d", rw.maxSize, 1000000)
+	}
+	if rw.maxFiles != 3 {
+		t.Errorf("maxFiles = %d, want 3", rw.maxFiles)
+	}
+
+	// File should have been created
+	if _, err := os.Stat(path); err != nil {
+		t.Errorf("log file not created: %v", err)
+	}
+}
+
+func TestNewRotateWriter_InvalidSize(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "test.log")
+
+	_, err := newRotateWriter(path, "notasize", 3)
+	if err == nil {
+		t.Fatal("expected error for invalid size")
+	}
+}
+
+func TestRotateWriter_Write(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "test.log")
+
+	rw, err := newRotateWriter(path, "1KB", 3)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer rw.Close()
+
+	// Write some data
+	data := []byte("hello world\n")
+	n, err := rw.Write(data)
+	if err != nil {
+		t.Fatalf("Write() error = %v", err)
+	}
+	if n != len(data) {
+		t.Errorf("Write() = %d, want %d", n, len(data))
+	}
+	if rw.size != int64(len(data)) {
+		t.Errorf("size = %d, want %d", rw.size, len(data))
+	}
+}
+
+func TestRotateWriter_Rotation(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "test.log")
+
+	// Use very small max size to trigger rotation
+	rw, err := newRotateWriter(path, "50B", 2)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer rw.Close()
+
+	// Write enough data to trigger rotation
+	bigData := []byte(strings.Repeat("x", 60))
+	if _, err := rw.Write(bigData); err != nil {
+		t.Fatalf("first Write() error = %v", err)
+	}
+
+	// This write should trigger rotation
+	if _, err := rw.Write(bigData); err != nil {
+		t.Fatalf("second Write() error = %v", err)
+	}
+
+	// Check that backup files were created
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var logFiles int
+	for _, e := range entries {
+		if strings.HasPrefix(e.Name(), "test.log") {
+			logFiles++
+		}
+	}
+	// Should have at least the current file + 1 backup
+	if logFiles < 2 {
+		t.Errorf("expected at least 2 log files, got %d", logFiles)
+	}
+}
+
+func TestRotateWriter_RemoveOldFiles(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "test.log")
+
+	// Create some fake backup files
+	for _, suffix := range []string{".20240101-120000", ".20240102-120000", ".20240103-120000", ".20240104-120000"} {
+		os.WriteFile(path+suffix, []byte("old"), 0644)
+	}
+
+	rw, err := newRotateWriter(path, "1KB", 2)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer rw.Close()
+
+	if err := rw.removeOldFiles(); err != nil {
+		t.Fatal(err)
+	}
+
+	// Check remaining backups
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var backups int
+	for _, e := range entries {
+		if strings.HasPrefix(e.Name(), "test.log.") {
+			backups++
+		}
+	}
+	if backups > 2 {
+		t.Errorf("expected at most 2 backups, got %d", backups)
+	}
+}
+
+func TestRotateWriter_Close(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "test.log")
+
+	rw, err := newRotateWriter(path, "1KB", 3)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if err := rw.Close(); err != nil {
+		t.Fatalf("Close() error = %v", err)
+	}
+
+	// Close on nil file should be safe
+	rw.file = nil
+	if err := rw.Close(); err != nil {
+		t.Fatalf("Close() on nil file error = %v", err)
+	}
+}

--- a/internal/utils/log/styles_test.go
+++ b/internal/utils/log/styles_test.go
@@ -1,0 +1,35 @@
+package log
+
+import (
+	"testing"
+)
+
+func TestDefaultStyles(t *testing.T) {
+	Reset()
+	defer Reset()
+
+	styles := DefaultStyles()
+	if styles == nil {
+		t.Fatal("DefaultStyles() returned nil")
+	}
+
+	// Calling again should return the same instance
+	styles2 := DefaultStyles()
+	if styles != styles2 {
+		t.Error("DefaultStyles() should return singleton")
+	}
+}
+
+func TestHighlight(t *testing.T) {
+	result := Highlight("test")
+	if result == "" {
+		t.Error("Highlight() returned empty string")
+	}
+}
+
+func TestUnderBold(t *testing.T) {
+	result := UnderBold("test")
+	if result == "" {
+		t.Error("UnderBold() returned empty string")
+	}
+}


### PR DESCRIPTION
## WHAT

Add 2,560 lines of new test code across 15 test files, covering all packages that contain testable logic. This brings test coverage from ~25% of source files to near-complete coverage (excluding declarative UI sub-components).

### New test files (13)
- **`internal/cli/cli_test.go`** — `expandPath`, `expandWindowsPaths`, `determineLogLevel`, `isForbiddenPath`, `syncStringSlice`, `Version.String`, `CLI.Run` dispatch, `Prune` arg validation, `parseTrashInfoFile`, `filterFiles`
- **`internal/trash/legacy/storage_test.go`** — Full Put/List/Restore/Remove lifecycle with temp directories, directory support, multiple files, custom restore destination
- **`internal/trash/xdg/storage_test.go`** — Full Put/List/Restore/Remove lifecycle, `.trashinfo` creation, name collision handling, directory support, orphan skipping, TrashInfo Save/Load roundtrip
- **`internal/trash/xdg/mountpoint_test.go`** — `isOnSameDevice`, `isValidExternalTrash` (symlink, regular file, valid dir), `createTrashDir`, `getMountPoints`
- **`internal/ui/state_test.go`** — ViewState transitions, date/origin toggles, YES input sequence/backspace/clear, `FormatDate`, `ViewType.String`
- **`internal/ui/selection_manager_test.go`** — Add/Remove/Contains/IndexOf with duplicate prevention
- **`internal/ui/components_test.go`** — `onlySpecialChars`, `isImageFile`
- **`internal/ui/update_test.go`** — `WindowSizeMsg`, `ErrorMsg`, `FileListLoadedMsg`, quit keys, detail view navigation, confirm dialog yes-no/type-YES, enter with selection
- **`internal/utils/debug/debug_test.go`** — `showExistingLogs`, non-existent/empty file handling
- **`internal/utils/fs/dir_test.go`** — `DirSize` with empty/nested dirs, symlink skipping, non-existent path error
- **`internal/utils/log/log_test.go`** — `New`, `AsDefault`, `Default`, `Reset`
- **`internal/utils/log/options_test.go`** — `DefaultOptions`, option functions, `EnableRotation` validation
- **`internal/utils/log/rotate_test.go`** — `rotateWriter` creation, write, rotation trigger, old file cleanup, close
- **`internal/utils/log/styles_test.go`** — `DefaultStyles` singleton, `Highlight`, `UnderBold`

### Enhanced existing tests (1)
- **`internal/config/config_test.go`** — Extended `TestNewDefaultConfig` with forbidden paths, PermanentDelete, Restore, logging rotation, preview, history exclude assertions

### Cross-platform fixes
- Use `filepath.Join`/`filepath.Clean` instead of hardcoded path separators for Windows compatibility
- Avoid file handle leaks in rotation tests that caused Windows CI cleanup failures
- `mountpoint_test.go` uses `//go:build !windows` tag; XDG storage tests skip on Windows via `runtime.GOOS` check

## WHY

Test coverage was at ~25% of source files with critical paths (CLI commands, both storage backends, UI logic, log rotation) completely untested. These tests establish a safety net for the core trash management lifecycle and catch regressions in path handling, forbidden path detection, state machine transitions, and cross-platform behavior.