### PR TITLE
Add golangci-lint configuration, CI lint job, and fix all lint issues

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @babarot

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -10,6 +10,21 @@ on:
   workflow_dispatch:
 
 jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Setup Go
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+          cache: true
+      - name: Run golangci-lint
+        uses: golangci/golangci-lint-action@v7
+        with:
+          version: latest
+
   build:
     strategy:
       matrix:

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -1,0 +1,35 @@
+version: "2"
+
+linters:
+  enable:
+    - govet
+    - staticcheck
+    - errcheck
+    - unused
+    - errorlint
+    # - gosec
+    - misspell
+    - revive
+    # - funcorder
+    - modernize
+  settings:
+    errcheck:
+      check-type-assertions: true
+    misspell:
+      locale: US
+    revive:
+      rules:
+        - name: unexported-return
+          disabled: true
+  exclusions:
+    presets:
+      - common-false-positives
+      - std-error-handling
+
+formatters:
+  enable:
+    - goimports
+  settings:
+    goimports:
+      local-prefixes:
+        - github.com/babarot/gomi

--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,10 @@ LDFLAGS := "-X main.version=$(shell git describe --tags --abbrev=0 --always) -X 
 all: build
 
 test: $(SRCS)
-	go test ./...
+	go test ./... -coverprofile=coverage.out -covermode=count
+
+lint:
+	golangci-lint run ./...
 
 deps:
 	go mod tidy
@@ -25,4 +28,4 @@ sys-install: build
 clean:
 	rm -f $(BINARY_NAME)
 
-.PHONY: all test deps build install clean
+.PHONY: all test lint deps build install clean

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -12,6 +12,9 @@ import (
 	"sync"
 	"time"
 
+	"github.com/jessevdk/go-flags"
+	"github.com/rs/xid"
+
 	"github.com/babarot/gomi/internal/config"
 	"github.com/babarot/gomi/internal/trash"
 	"github.com/babarot/gomi/internal/trash/legacy"
@@ -19,8 +22,6 @@ import (
 	"github.com/babarot/gomi/internal/utils/debug"
 	"github.com/babarot/gomi/internal/utils/env"
 	"github.com/babarot/gomi/internal/utils/log"
-	"github.com/jessevdk/go-flags"
-	"github.com/rs/xid"
 )
 
 type Option struct {

--- a/internal/cli/cli_test.go
+++ b/internal/cli/cli_test.go
@@ -2,7 +2,6 @@ package cli
 
 import (
 	"bytes"
-	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
@@ -165,13 +164,13 @@ func TestSyncStringSlice_Concurrent(t *testing.T) {
 	done := make(chan struct{})
 
 	// Concurrent writes
-	for i := 0; i < 100; i++ {
+	for range 100 {
 		go func() {
 			s.Append("item")
 			done <- struct{}{}
 		}()
 	}
-	for i := 0; i < 100; i++ {
+	for range 100 {
 		<-done
 	}
 
@@ -234,7 +233,9 @@ func TestCLI_Run_Version(t *testing.T) {
 	}
 
 	var buf bytes.Buffer
-	buf.ReadFrom(r)
+	if _, err := buf.ReadFrom(r); err != nil {
+		t.Fatalf("ReadFrom() error = %v", err)
+	}
 	output := buf.String()
 	if !strings.Contains(output, "1.0.0") {
 		t.Errorf("version output should contain version, got %q", output)
@@ -298,7 +299,7 @@ func TestParseTrashInfoFile(t *testing.T) {
 	dir := t.TempDir()
 	infoFile := filepath.Join(dir, "test.trashinfo")
 
-	content := fmt.Sprintf("[Trash Info]\nPath=/home/user/test.txt\nDeletionDate=2024-06-15T10:30:00\n")
+	content := "[Trash Info]\nPath=/home/user/test.txt\nDeletionDate=2024-06-15T10:30:00\n"
 	if err := os.WriteFile(infoFile, []byte(content), 0644); err != nil {
 		t.Fatal(err)
 	}
@@ -321,7 +322,9 @@ func TestParseTrashInfoFile(t *testing.T) {
 func TestParseTrashInfoFile_InvalidDate(t *testing.T) {
 	dir := t.TempDir()
 	infoFile := filepath.Join(dir, "bad.trashinfo")
-	os.WriteFile(infoFile, []byte("Path=/foo\nDeletionDate=not-a-date\n"), 0644)
+	if err := os.WriteFile(infoFile, []byte("Path=/foo\nDeletionDate=not-a-date\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
 
 	_, err := parseTrashInfoFile(infoFile)
 	if err == nil {
@@ -356,9 +359,8 @@ func TestOrphanedFile_Getters(t *testing.T) {
 	if o.GetName() != "test.trashinfo" {
 		t.Errorf("GetName() = %q, want %q", o.GetName(), "test.trashinfo")
 	}
-	if o.GetDeletedAt().IsZero() {
-		// zero value is fine, just make sure it doesn't panic
-	}
+	// GetDeletedAt() should not panic on zero value
+	_ = o.GetDeletedAt()
 }
 
 func TestFilterFiles(t *testing.T) {
@@ -366,7 +368,9 @@ func TestFilterFiles(t *testing.T) {
 
 	// Create a real file to represent an existing trash entry
 	existingFile := filepath.Join(dir, "exists.txt")
-	os.WriteFile(existingFile, []byte("hi"), 0644)
+	if err := os.WriteFile(existingFile, []byte("hi"), 0644); err != nil {
+		t.Fatal(err)
+	}
 
 	cli := &CLI{config: config.NewDefaultConfig()}
 

--- a/internal/cli/prune.go
+++ b/internal/cli/prune.go
@@ -9,12 +9,13 @@ import (
 	"strings"
 	"time"
 
+	"github.com/fatih/color"
+
 	"github.com/babarot/gomi/internal/trash"
 	"github.com/babarot/gomi/internal/trash/xdg"
 	"github.com/babarot/gomi/internal/ui"
 	"github.com/babarot/gomi/internal/ui/table"
 	"github.com/babarot/gomi/internal/utils/duration"
-	"github.com/fatih/color"
 )
 
 var (
@@ -303,11 +304,11 @@ func parseTrashInfoFile(path string) (OrphanedFile, error) {
 	var originalPath string
 
 	for _, line := range lines {
-		if strings.HasPrefix(line, "Path=") {
-			originalPath = strings.TrimPrefix(line, "Path=")
+		if after, ok := strings.CutPrefix(line, "Path="); ok {
+			originalPath = after
 		}
-		if strings.HasPrefix(line, "DeletionDate=") {
-			deletedAtStr := strings.TrimPrefix(line, "DeletionDate=")
+		if after, ok := strings.CutPrefix(line, "DeletionDate="); ok {
+			deletedAtStr := after
 			deletedAt, err = time.Parse("2006-01-02T15:04:05", deletedAtStr)
 			if err != nil {
 				return OrphanedFile{}, err

--- a/internal/cli/put.go
+++ b/internal/cli/put.go
@@ -9,8 +9,9 @@ import (
 	"strings"
 	"sync"
 
-	"github.com/babarot/gomi/internal/utils/fs"
 	"golang.org/x/sync/errgroup"
+
+	"github.com/babarot/gomi/internal/utils/fs"
 )
 
 // Put moves files to trash
@@ -29,7 +30,6 @@ func (c *CLI) Put(args []string) error {
 	)
 
 	for _, arg := range args {
-		arg := arg // Create new instance of arg for goroutine
 		eg.Go(func() error {
 			return c.processFile(arg, failed)
 		})

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -3,6 +3,7 @@
 package config
 
 import (
+	"errors"
 	"fmt"
 	"log/slog"
 	"os"
@@ -10,9 +11,10 @@ import (
 	"reflect"
 	"strings"
 
-	"github.com/babarot/gomi/internal/utils/shell"
 	"github.com/go-playground/validator/v10"
 	"gopkg.in/yaml.v2"
+
+	"github.com/babarot/gomi/internal/utils/shell"
 )
 
 // Config represents the root configuration structure that holds all application settings.
@@ -310,7 +312,8 @@ func (c *Config) validate() error {
 	_ = validate.RegisterValidation("validDirPath", validateDirPath)
 
 	if err := validate.Struct(c); err != nil {
-		if validationErrors, ok := err.(validator.ValidationErrors); ok {
+		var validationErrors validator.ValidationErrors
+		if errors.As(err, &validationErrors) {
 			for _, err := range validationErrors {
 				return fmt.Errorf("validation error: Field %s, %q is invalid", err.Field(), err.Value())
 			}
@@ -342,12 +345,12 @@ func (c *Config) setDefault() {
 	if c.UI.Style.DeletionDialog == "" {
 		c.UI.Style.DeletionDialog = "205"
 	}
-	
+
 	// Set color for filter match highlighting
 	if c.UI.Style.ListView.FilterMatch == "" {
 		c.UI.Style.ListView.FilterMatch = "#F39C12"
 	}
-	
+
 	// Set color for filter prompt
 	if c.UI.Style.ListView.FilterPrompt == "" {
 		c.UI.Style.ListView.FilterPrompt = "#7AA2F7"

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -168,7 +168,9 @@ func TestEnsureConfig(t *testing.T) {
 func TestEnsureConfig_ExistingFile(t *testing.T) {
 	tmpDir := t.TempDir()
 	configPath := filepath.Join(tmpDir, "config.yaml")
-	os.WriteFile(configPath, []byte("core:\n  trash:\n    strategy: auto\n"), 0644)
+	if err := os.WriteFile(configPath, []byte("core:\n  trash:\n    strategy: auto\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
 
 	cfg, err := ensureConfig(configPath)
 	if err != nil {
@@ -192,7 +194,9 @@ history:
   include:
     within_days: 30
 `
-	os.WriteFile(configPath, []byte(content), 0644)
+	if err := os.WriteFile(configPath, []byte(content), 0644); err != nil {
+		t.Fatal(err)
+	}
 
 	cfg := &Config{}
 	if err := cfg.load(configPath); err != nil {

--- a/internal/config/validation.go
+++ b/internal/config/validation.go
@@ -1,6 +1,7 @@
 package config
 
 import (
+	"errors"
 	"os"
 	"path/filepath"
 	"regexp"
@@ -137,7 +138,8 @@ func validateDirPath(fl validator.FieldLevel) bool {
 			// Path doesn't exist but format is valid
 			return true
 		}
-		if _, ok := err.(*os.PathError); ok {
+		pathError := &os.PathError{}
+		if errors.As(err, &pathError) {
 			// Path error indicates possible OS constraint violation
 			return false
 		}

--- a/internal/trash/errors_test.go
+++ b/internal/trash/errors_test.go
@@ -36,7 +36,7 @@ func TestStorageError_Error(t *testing.T) {
 func TestStorageError_Unwrap(t *testing.T) {
 	inner := fmt.Errorf("inner error")
 	se := &StorageError{Op: "put", Path: "/tmp/file", Err: inner}
-	if got := se.Unwrap(); got != inner {
+	if got := se.Unwrap(); !errors.Is(got, inner) {
 		t.Errorf("Unwrap() = %v, want %v", got, inner)
 	}
 }
@@ -47,7 +47,7 @@ func TestNewStorageError(t *testing.T) {
 	if !errors.As(err, &se) {
 		t.Fatal("expected *StorageError")
 	}
-	if se.Op != "restore" || se.Path != "/tmp/file" || se.Err != ErrNotFound {
+	if se.Op != "restore" || se.Path != "/tmp/file" || !errors.Is(se.Err, ErrNotFound) {
 		t.Errorf("unexpected fields: %+v", se)
 	}
 }

--- a/internal/trash/filter.go
+++ b/internal/trash/filter.go
@@ -4,13 +4,15 @@ import (
 	"fmt"
 	"log/slog"
 	"regexp"
+	"slices"
 	"time"
 
-	"github.com/babarot/gomi/internal/config"
-	"github.com/babarot/gomi/internal/utils/fs"
 	"github.com/docker/go-units"
 	"github.com/gobwas/glob"
 	"github.com/k1LoW/duration"
+
+	"github.com/babarot/gomi/internal/config"
+	"github.com/babarot/gomi/internal/utils/fs"
 )
 
 // Filterable defines the interface that trashed files must implement to be filtered
@@ -75,13 +77,7 @@ func rejectByNames[T Filterable](items []T, excludeFiles []string) []T {
 
 	var filtered []T
 	for _, item := range items {
-		excluded := false
-		for _, exclude := range excludeFiles {
-			if item.GetName() == exclude {
-				excluded = true
-				break
-			}
-		}
+		excluded := slices.Contains(excludeFiles, item.GetName())
 		if !excluded {
 			filtered = append(filtered, item)
 		}

--- a/internal/trash/filter_test.go
+++ b/internal/trash/filter_test.go
@@ -2,6 +2,7 @@ package trash
 
 import (
 	"fmt"
+	"slices"
 	"testing"
 	"time"
 
@@ -108,13 +109,7 @@ func TestRejectBySize(t *testing.T) {
 
 			// Check if remaining items match expected names
 			for _, item := range filtered {
-				found := false
-				for _, expectedName := range tc.expectedNames {
-					if item.GetName() == expectedName {
-						found = true
-						break
-					}
-				}
+				found := slices.Contains(tc.expectedNames, item.GetName())
 				if !found {
 					t.Errorf("Unexpected item in filtered list: %s", item.GetName())
 				}
@@ -175,13 +170,7 @@ func TestFilter(t *testing.T) {
 
 			// Check if remaining items match expected names
 			for _, item := range filtered {
-				found := false
-				for _, expectedName := range tc.expectedNames {
-					if item.GetName() == expectedName {
-						found = true
-						break
-					}
-				}
+				found := slices.Contains(tc.expectedNames, item.GetName())
 				if !found {
 					t.Errorf("Unexpected item in filtered list: %s", item.GetName())
 				}

--- a/internal/trash/legacy/history/history.go
+++ b/internal/trash/legacy/history/history.go
@@ -8,10 +8,11 @@ import (
 	"path/filepath"
 	"time"
 
-	"github.com/babarot/gomi/internal/config"
-	"github.com/babarot/gomi/internal/trash"
 	"github.com/k0kubun/pp/v3"
 	"github.com/rs/xid"
+
+	"github.com/babarot/gomi/internal/config"
+	"github.com/babarot/gomi/internal/trash"
 )
 
 const (

--- a/internal/trash/legacy/history/history_test.go
+++ b/internal/trash/legacy/history/history_test.go
@@ -175,8 +175,13 @@ func TestHistory_Open(t *testing.T) {
 				{Name: "test.txt", ID: "abc", From: "/home/test.txt", To: filepath.Join(dir, "test.txt")},
 			},
 		}
-		data, _ := json.Marshal(historyData)
-		os.WriteFile(filepath.Join(dir, Filename), data, 0644)
+		data, err := json.Marshal(historyData)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(filepath.Join(dir, Filename), data, 0644); err != nil {
+			t.Fatal(err)
+		}
 
 		h := New(dir, config.History{})
 		if err := h.Open(); err != nil {
@@ -191,7 +196,9 @@ func TestHistory_Open(t *testing.T) {
 func TestHistory_Update(t *testing.T) {
 	dir := t.TempDir()
 	h := New(dir, config.History{})
-	h.Open()
+	if err := h.Open(); err != nil {
+		t.Fatal(err)
+	}
 
 	newFiles := []File{
 		{Name: "a.txt", ID: "id1"},
@@ -213,7 +220,9 @@ func TestHistory_Update(t *testing.T) {
 		t.Fatal(err)
 	}
 	var saved History
-	json.Unmarshal(data, &saved)
+	if err := json.Unmarshal(data, &saved); err != nil {
+		t.Fatal(err)
+	}
 	if len(saved.Files) != 2 {
 		t.Errorf("saved %d files, want 2", len(saved.Files))
 	}
@@ -229,9 +238,14 @@ func TestHistory_Save(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	data, _ := os.ReadFile(filepath.Join(dir, Filename))
+	data, err := os.ReadFile(filepath.Join(dir, Filename))
+	if err != nil {
+		t.Fatal(err)
+	}
 	var saved History
-	json.Unmarshal(data, &saved)
+	if err := json.Unmarshal(data, &saved); err != nil {
+		t.Fatal(err)
+	}
 	if len(saved.Files) != 1 {
 		t.Errorf("saved %d files, want 1", len(saved.Files))
 	}

--- a/internal/trash/legacy/storage.go
+++ b/internal/trash/legacy/storage.go
@@ -8,10 +8,11 @@ import (
 	"path/filepath"
 	"time"
 
+	"github.com/google/uuid"
+
 	"github.com/babarot/gomi/internal/trash"
 	"github.com/babarot/gomi/internal/trash/legacy/history"
 	"github.com/babarot/gomi/internal/utils/fs"
-	"github.com/google/uuid"
 )
 
 // Storage implements the trash.Storage interface for legacy (.gomi) storage
@@ -114,7 +115,7 @@ func (s *Storage) Put(src string) error {
 			return trash.NewStorageError(
 				"put",
 				src,
-				fmt.Errorf("failed to save history and rollback failed: %v (original error: %w)", moveErr, err))
+				fmt.Errorf("failed to save history and rollback failed: %w (original error: %w)", moveErr, err))
 		}
 		return trash.NewStorageError(
 			"put",

--- a/internal/trash/legacy/storage_test.go
+++ b/internal/trash/legacy/storage_test.go
@@ -199,9 +199,15 @@ func TestStorage_PutDirectory(t *testing.T) {
 	// Create a directory with files
 	srcDir := t.TempDir()
 	testDir := filepath.Join(srcDir, "mydir")
-	os.MkdirAll(filepath.Join(testDir, "sub"), 0755)
-	os.WriteFile(filepath.Join(testDir, "a.txt"), []byte("a"), 0644)
-	os.WriteFile(filepath.Join(testDir, "sub", "b.txt"), []byte("b"), 0644)
+	if err := os.MkdirAll(filepath.Join(testDir, "sub"), 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(testDir, "a.txt"), []byte("a"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(testDir, "sub", "b.txt"), []byte("b"), 0644); err != nil {
+		t.Fatal(err)
+	}
 
 	if err := s.Put(testDir); err != nil {
 		t.Fatalf("Put(dir) error = %v", err)
@@ -271,7 +277,9 @@ func TestStorage_PutMultipleFiles(t *testing.T) {
 
 	srcDir := t.TempDir()
 	for _, name := range []string{"a.txt", "b.txt", "c.txt"} {
-		os.WriteFile(filepath.Join(srcDir, name), []byte(name), 0644)
+		if err := os.WriteFile(filepath.Join(srcDir, name), []byte(name), 0644); err != nil {
+			t.Fatal(err)
+		}
 	}
 
 	for _, name := range []string{"a.txt", "b.txt", "c.txt"} {

--- a/internal/trash/manager_additional_test.go
+++ b/internal/trash/manager_additional_test.go
@@ -47,7 +47,9 @@ func TestNewManager(t *testing.T) {
 func TestManager_Put(t *testing.T) {
 	tmpDir := t.TempDir()
 	testFile := filepath.Join(tmpDir, "test.txt")
-	os.WriteFile(testFile, []byte("hello"), 0644)
+	if err := os.WriteFile(testFile, []byte("hello"), 0644); err != nil {
+		t.Fatal(err)
+	}
 
 	t.Run("success on first storage", func(t *testing.T) {
 		m := &Manager{
@@ -194,7 +196,9 @@ func TestManager_Restore(t *testing.T) {
 	t.Run("destination already exists", func(t *testing.T) {
 		tmpDir := t.TempDir()
 		existing := filepath.Join(tmpDir, "exists.txt")
-		os.WriteFile(existing, []byte("data"), 0644)
+		if err := os.WriteFile(existing, []byte("data"), 0644); err != nil {
+			t.Fatal(err)
+		}
 
 		m := &Manager{
 			storages: []Storage{

--- a/internal/trash/manager_test.go
+++ b/internal/trash/manager_test.go
@@ -117,9 +117,9 @@ type mockStorage struct {
 	listErr     error
 }
 
-func (m *mockStorage) Put(src string) error        { return m.putErr }
+func (m *mockStorage) Put(src string) error              { return m.putErr }
 func (m *mockStorage) Restore(f *File, dst string) error { return m.restoreErr }
-func (m *mockStorage) Remove(f *File) error         { return m.removeErr }
+func (m *mockStorage) Remove(f *File) error              { return m.removeErr }
 
 func (m *mockStorage) List() ([]*File, error) {
 	return m.files, m.listErr

--- a/internal/trash/storage_test.go
+++ b/internal/trash/storage_test.go
@@ -49,7 +49,9 @@ func TestFile_Getters(t *testing.T) {
 func TestFile_Exists(t *testing.T) {
 	tmpDir := t.TempDir()
 	existing := filepath.Join(tmpDir, "exists.txt")
-	os.WriteFile(existing, []byte("hello"), 0644)
+	if err := os.WriteFile(existing, []byte("hello"), 0644); err != nil {
+		t.Fatal(err)
+	}
 
 	tests := []struct {
 		name      string
@@ -74,10 +76,14 @@ func TestFile_RequiresAdmin(t *testing.T) {
 	tmpDir := t.TempDir()
 
 	writable := filepath.Join(tmpDir, "writable.txt")
-	os.WriteFile(writable, []byte("hello"), 0644)
+	if err := os.WriteFile(writable, []byte("hello"), 0644); err != nil {
+		t.Fatal(err)
+	}
 
 	readonly := filepath.Join(tmpDir, "readonly.txt")
-	os.WriteFile(readonly, []byte("hello"), 0444)
+	if err := os.WriteFile(readonly, []byte("hello"), 0444); err != nil {
+		t.Fatal(err)
+	}
 
 	tests := []struct {
 		name      string

--- a/internal/trash/xdg/info_test.go
+++ b/internal/trash/xdg/info_test.go
@@ -15,7 +15,7 @@ func TestNewInfo(t *testing.T) {
 		check   func(t *testing.T, info *TrashInfo)
 	}{
 		{
-			name: "valid trashinfo",
+			name:  "valid trashinfo",
 			input: "[Trash Info]\nPath=/home/user/file.txt\nDeletionDate=2024-01-15T10:30:00\n",
 			check: func(t *testing.T, info *TrashInfo) {
 				if info.Path != "/home/user/file.txt" {
@@ -31,7 +31,7 @@ func TestNewInfo(t *testing.T) {
 			},
 		},
 		{
-			name: "encoded path with spaces",
+			name:  "encoded path with spaces",
 			input: "[Trash Info]\nPath=/home/user/my%20file.txt\nDeletionDate=2024-01-15T10:30:00\n",
 			check: func(t *testing.T, info *TrashInfo) {
 				if info.Path != "/home/user/my file.txt" {
@@ -40,7 +40,7 @@ func TestNewInfo(t *testing.T) {
 			},
 		},
 		{
-			name: "with comments and blank lines",
+			name:  "with comments and blank lines",
 			input: "# comment\n\n[Trash Info]\n\nPath=/tmp/file\nDeletionDate=2024-01-01T00:00:00\n",
 			check: func(t *testing.T, info *TrashInfo) {
 				if info.Path != "/tmp/file" {

--- a/internal/trash/xdg/mountpoint.go
+++ b/internal/trash/xdg/mountpoint.go
@@ -7,11 +7,13 @@ import (
 	"log/slog"
 	"os"
 	"path/filepath"
+	"slices"
 	"strings"
 	"syscall"
 
-	"github.com/babarot/gomi/internal/trash"
 	"github.com/moby/sys/mountinfo"
+
+	"github.com/babarot/gomi/internal/trash"
 )
 
 // Unix/Linux implementation of XDG trash handling
@@ -51,12 +53,9 @@ func getMountPoints() ([]string, error) {
 		}
 
 		// Skip read-only filesystems
-		opts := strings.Split(info.Options, ",")
-		for _, opt := range opts {
-			if opt == "ro" {
-				slog.Debug("skipping read-only filesystem", "mountpoint", info.Mountpoint)
-				return true, false
-			}
+		if slices.Contains(strings.Split(info.Options, ","), "ro") {
+			slog.Debug("skipping read-only filesystem", "mountpoint", info.Mountpoint)
+			return true, false
 		}
 
 		return false, false
@@ -84,38 +83,6 @@ func getMountPoints() ([]string, error) {
 	}
 
 	return points, nil
-}
-
-// getMountPoint returns the mount point for the given path
-func getMountPoint(path string) (string, error) {
-	absPath, err := filepath.Abs(path)
-	if err != nil {
-		return "", fmt.Errorf("failed to get absolute path: %w", err)
-	}
-
-	// Get all mount points
-	mounts, err := mountinfo.GetMounts(nil)
-	if err != nil {
-		return "", fmt.Errorf("failed to get mount info: %w", err)
-	}
-
-	// Find the longest matching mount point
-	var longest string
-	for _, m := range mounts {
-		if strings.HasPrefix(absPath, m.Mountpoint) {
-			if len(m.Mountpoint) > len(longest) {
-				longest = m.Mountpoint
-			}
-		}
-	}
-
-	if longest == "" {
-		// If no mount point found, the path must be on the root filesystem
-		return "/", nil
-	}
-
-	slog.Debug("found mount point", "path", absPath, "mountpoint", longest)
-	return longest, nil
 }
 
 // isOnSameDevice checks if two paths are on the same device

--- a/internal/trash/xdg/mountpoint_test.go
+++ b/internal/trash/xdg/mountpoint_test.go
@@ -5,6 +5,7 @@ package xdg
 import (
 	"os"
 	"path/filepath"
+	"slices"
 	"testing"
 )
 
@@ -13,8 +14,12 @@ func TestIsOnSameDevice(t *testing.T) {
 
 	fileA := filepath.Join(dir, "a.txt")
 	fileB := filepath.Join(dir, "b.txt")
-	os.WriteFile(fileA, []byte("a"), 0644)
-	os.WriteFile(fileB, []byte("b"), 0644)
+	if err := os.WriteFile(fileA, []byte("a"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(fileB, []byte("b"), 0644); err != nil {
+		t.Fatal(err)
+	}
 
 	same, err := isOnSameDevice(fileA, fileB)
 	if err != nil {
@@ -37,8 +42,12 @@ func TestIsOnSameDevice_WithSymlink(t *testing.T) {
 	real := filepath.Join(dir, "real.txt")
 	link := filepath.Join(dir, "link.txt")
 
-	os.WriteFile(real, []byte("data"), 0644)
-	os.Symlink(real, link)
+	if err := os.WriteFile(real, []byte("data"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink(real, link); err != nil {
+		t.Fatal(err)
+	}
 
 	same, err := isOnSameDevice(real, link)
 	if err != nil {
@@ -58,7 +67,9 @@ func TestIsValidExternalTrash_NotExists(t *testing.T) {
 func TestIsValidExternalTrash_RegularFile(t *testing.T) {
 	dir := t.TempDir()
 	file := filepath.Join(dir, "notadir")
-	os.WriteFile(file, []byte("x"), 0644)
+	if err := os.WriteFile(file, []byte("x"), 0644); err != nil {
+		t.Fatal(err)
+	}
 
 	if isValidExternalTrash(file) {
 		t.Error("regular file should not be valid external trash")
@@ -68,8 +79,12 @@ func TestIsValidExternalTrash_RegularFile(t *testing.T) {
 func TestIsValidExternalTrash_ValidDir(t *testing.T) {
 	dir := t.TempDir()
 	trashDir := filepath.Join(dir, ".Trash-1000")
-	os.MkdirAll(filepath.Join(trashDir, "files"), 0700)
-	os.MkdirAll(filepath.Join(trashDir, "info"), 0700)
+	if err := os.MkdirAll(filepath.Join(trashDir, "files"), 0700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(filepath.Join(trashDir, "info"), 0700); err != nil {
+		t.Fatal(err)
+	}
 
 	if !isValidExternalTrash(trashDir) {
 		t.Error("properly structured trash dir should be valid")
@@ -79,11 +94,17 @@ func TestIsValidExternalTrash_ValidDir(t *testing.T) {
 func TestIsValidExternalTrash_Symlink(t *testing.T) {
 	dir := t.TempDir()
 	realDir := filepath.Join(dir, "real")
-	os.MkdirAll(filepath.Join(realDir, "files"), 0700)
-	os.MkdirAll(filepath.Join(realDir, "info"), 0700)
+	if err := os.MkdirAll(filepath.Join(realDir, "files"), 0700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(filepath.Join(realDir, "info"), 0700); err != nil {
+		t.Fatal(err)
+	}
 
 	linkDir := filepath.Join(dir, "link")
-	os.Symlink(realDir, linkDir)
+	if err := os.Symlink(realDir, linkDir); err != nil {
+		t.Fatal(err)
+	}
 
 	if isValidExternalTrash(linkDir) {
 		t.Error("symlink should not be valid external trash")
@@ -125,11 +146,8 @@ func TestGetMountPoints(t *testing.T) {
 
 	// Root should always be present
 	var hasRoot bool
-	for _, p := range points {
-		if p == "/" {
-			hasRoot = true
-			break
-		}
+	if slices.Contains(points, "/") {
+		hasRoot = true
 	}
 	if !hasRoot {
 		t.Error("mount points should include /")

--- a/internal/trash/xdg/storage_test.go
+++ b/internal/trash/xdg/storage_test.go
@@ -110,7 +110,9 @@ func TestStorage_Put_CreatesTrashInfo(t *testing.T) {
 
 	srcDir := t.TempDir()
 	srcFile := filepath.Join(srcDir, "check_info.txt")
-	os.WriteFile(srcFile, []byte("data"), 0644)
+	if err := os.WriteFile(srcFile, []byte("data"), 0644); err != nil {
+		t.Fatal(err)
+	}
 
 	if err := s.Put(srcFile); err != nil {
 		t.Fatal(err)
@@ -139,10 +141,12 @@ func TestStorage_Put_CollisionHandling(t *testing.T) {
 	s, _ := newTestStorage(t)
 
 	// Trash two files with the same name from different directories
-	for i := 0; i < 2; i++ {
+	for i := range 2 {
 		srcDir := t.TempDir()
 		srcFile := filepath.Join(srcDir, "dup.txt")
-		os.WriteFile(srcFile, []byte("content"), 0644)
+		if err := os.WriteFile(srcFile, []byte("content"), 0644); err != nil {
+			t.Fatal(err)
+		}
 
 		if err := s.Put(srcFile); err != nil {
 			t.Fatalf("Put() #%d error = %v", i, err)
@@ -164,7 +168,9 @@ func TestStorage_Restore(t *testing.T) {
 	srcDir := t.TempDir()
 	srcFile := filepath.Join(srcDir, "restore_me.txt")
 	content := []byte("restore this")
-	os.WriteFile(srcFile, content, 0644)
+	if err := os.WriteFile(srcFile, content, 0644); err != nil {
+		t.Fatal(err)
+	}
 
 	if err := s.Put(srcFile); err != nil {
 		t.Fatal(err)
@@ -206,7 +212,9 @@ func TestStorage_Restore_CustomDst(t *testing.T) {
 
 	srcDir := t.TempDir()
 	srcFile := filepath.Join(srcDir, "original.txt")
-	os.WriteFile(srcFile, []byte("data"), 0644)
+	if err := os.WriteFile(srcFile, []byte("data"), 0644); err != nil {
+		t.Fatal(err)
+	}
 
 	if err := s.Put(srcFile); err != nil {
 		t.Fatal(err)
@@ -233,7 +241,9 @@ func TestStorage_Remove(t *testing.T) {
 
 	srcDir := t.TempDir()
 	srcFile := filepath.Join(srcDir, "delete_me.txt")
-	os.WriteFile(srcFile, []byte("bye"), 0644)
+	if err := os.WriteFile(srcFile, []byte("bye"), 0644); err != nil {
+		t.Fatal(err)
+	}
 
 	if err := s.Put(srcFile); err != nil {
 		t.Fatal(err)
@@ -273,9 +283,15 @@ func TestStorage_PutDirectory(t *testing.T) {
 
 	srcDir := t.TempDir()
 	testDir := filepath.Join(srcDir, "mydir")
-	os.MkdirAll(filepath.Join(testDir, "sub"), 0755)
-	os.WriteFile(filepath.Join(testDir, "a.txt"), []byte("a"), 0644)
-	os.WriteFile(filepath.Join(testDir, "sub", "b.txt"), []byte("b"), 0644)
+	if err := os.MkdirAll(filepath.Join(testDir, "sub"), 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(testDir, "a.txt"), []byte("a"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(testDir, "sub", "b.txt"), []byte("b"), 0644); err != nil {
+		t.Fatal(err)
+	}
 
 	if err := s.Put(testDir); err != nil {
 		t.Fatalf("Put(dir) error = %v", err)
@@ -318,7 +334,9 @@ func TestStorage_List_SkipsInvalidInfo(t *testing.T) {
 	trashRoot := filepath.Join(dataDir, "Trash")
 
 	// Create a file in files/ without a matching .trashinfo
-	os.WriteFile(filepath.Join(trashRoot, "files", "orphan.txt"), []byte("orphan"), 0644)
+	if err := os.WriteFile(filepath.Join(trashRoot, "files", "orphan.txt"), []byte("orphan"), 0644); err != nil {
+		t.Fatal(err)
+	}
 
 	files, err := s.List()
 	if err != nil {
@@ -365,7 +383,9 @@ func TestTrashInfo_Save_NoOverwrite(t *testing.T) {
 	infoPath := filepath.Join(dir, "existing.trashinfo")
 
 	// Create an existing file
-	os.WriteFile(infoPath, []byte("existing"), 0644)
+	if err := os.WriteFile(infoPath, []byte("existing"), 0644); err != nil {
+		t.Fatal(err)
+	}
 
 	info := &TrashInfo{
 		Path:         "/tmp/file",

--- a/internal/ui/commands.go
+++ b/internal/ui/commands.go
@@ -22,12 +22,12 @@ func loadFileListCmd(files []File) tea.Cmd {
 
 		// Sort files by deletion time, newest first
 		sort.Slice(files, func(i, j int) bool {
-			return files[i].File.DeletedAt.After(files[j].File.DeletedAt)
+			return files[i].DeletedAt.After(files[j].DeletedAt)
 		})
 
 		// Filter out files that no longer exist
 		files = lo.Reject(files, func(f File, index int) bool {
-			_, err := os.Stat(f.File.TrashPath)
+			_, err := os.Stat(f.TrashPath)
 			return os.IsNotExist(err)
 		})
 
@@ -54,7 +54,7 @@ func deletePermanentlyCmd(m *Model, files ...File) tea.Cmd {
 		// Refresh file list after deletion
 		origin := m.files
 		origin = lo.Reject(origin, func(f File, index int) bool {
-			_, err := os.Stat(f.File.TrashPath)
+			_, err := os.Stat(f.TrashPath)
 			return os.IsNotExist(err)
 		})
 

--- a/internal/ui/components.go
+++ b/internal/ui/components.go
@@ -7,11 +7,12 @@ import (
 	"regexp"
 	"strings"
 
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/jimschubert/answer/validate"
+
 	"github.com/babarot/gomi/internal/trash"
 	"github.com/babarot/gomi/internal/ui/components/confirm"
 	"github.com/babarot/gomi/internal/ui/components/input"
-	tea "github.com/charmbracelet/bubbletea"
-	"github.com/jimschubert/answer/validate"
 )
 
 func Confirm(prompt string) bool {
@@ -42,7 +43,11 @@ func ConfirmYes(prompt string) bool {
 		return false
 	}
 
-	return p.(*confirm.YesValidationModel).IsAccepted()
+	m2, ok := p.(*confirm.YesValidationModel)
+	if !ok {
+		return false
+	}
+	return m2.IsAccepted()
 }
 
 func InputFilename(file *trash.File) (string, error) {

--- a/internal/ui/components/confirm/rendering.go
+++ b/internal/ui/components/confirm/rendering.go
@@ -201,10 +201,7 @@ func (i *inputRenderer) Init() tea.Cmd {
 	input.PromptStyle = i.m.Styles.Prompt
 	input.PlaceholderStyle = i.m.Styles.Placeholder
 	input.TextStyle = i.m.Styles.Text
-	input.CharLimit = len(i.m.AcceptedDecisionText)
-	if len(i.m.DeniedDecisionText) > input.CharLimit {
-		input.CharLimit = len(i.m.DeniedDecisionText)
-	}
+	input.CharLimit = max(len(i.m.DeniedDecisionText), len(i.m.AcceptedDecisionText))
 	input.Focus()
 	i.text = input
 	return nil
@@ -217,8 +214,8 @@ func (i *inputRenderer) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 
 	switch msg := msg.(type) {
 	case tea.KeyMsg:
-		switch {
-		case msg.Type == tea.KeyEnter:
+		switch msg.Type {
+		case tea.KeyEnter:
 			switch k := strings.ToLower(i.text.Value()); {
 			case strings.HasPrefix(k, strings.ToLower(i.m.AcceptedDecisionText)):
 				i.m.SetDecision(Accepted)
@@ -295,10 +292,7 @@ func (i *immediateRenderer) Init() tea.Cmd {
 	input.PromptStyle = i.m.Styles.Prompt
 	input.PlaceholderStyle = i.m.Styles.Placeholder
 	input.TextStyle = i.m.Styles.Text
-	input.CharLimit = len(i.m.AcceptedDecisionText)
-	if len(i.m.DeniedDecisionText) > input.CharLimit {
-		input.CharLimit = len(i.m.DeniedDecisionText)
-	}
+	input.CharLimit = max(len(i.m.DeniedDecisionText), len(i.m.AcceptedDecisionText))
 	input.Focus()
 	i.text = input
 	return nil
@@ -313,8 +307,8 @@ func (i *immediateRenderer) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 
 	switch msg := msg.(type) {
 	case tea.KeyMsg:
-		switch {
-		case msg.Type == tea.KeyCtrlC, msg.Type == tea.KeyEsc:
+		switch msg.Type {
+		case tea.KeyCtrlC, tea.KeyEsc:
 			i.m.SetDecision(Denied)
 			i.m.done = true
 			return i.m, tea.Quit

--- a/internal/ui/components/input/input.go
+++ b/internal/ui/components/input/input.go
@@ -233,9 +233,10 @@ func (m *Model) View() string {
 		}
 	}
 
-	if m.done == userQuit {
+	switch m.done {
+	case userQuit:
 		return ""
-	} else if m.done == userEnter {
+	case userEnter:
 		// rather than clearing the program output, we want to show the question + answer just as AlecAivazis/survey did
 		if m.Prompt != "" {
 			b.WriteString(m.Styles.Prompt.Inline(true).Render(m.Prompt))

--- a/internal/ui/delegate.go
+++ b/internal/ui/delegate.go
@@ -5,12 +5,13 @@ import (
 	"io"
 	"strings"
 
-	"github.com/babarot/gomi/internal/config"
 	"github.com/charmbracelet/bubbles/key"
 	"github.com/charmbracelet/bubbles/list"
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/charmbracelet/lipgloss"
 	"github.com/charmbracelet/x/ansi"
+
+	"github.com/babarot/gomi/internal/config"
 )
 
 var (

--- a/internal/ui/file.go
+++ b/internal/ui/file.go
@@ -42,31 +42,31 @@ func (f File) isSelected() bool {
 }
 
 func (f File) Description() string {
-	_, err := os.Stat(f.File.TrashPath)
+	_, err := os.Stat(f.TrashPath)
 	if os.IsNotExist(err) {
 		return "(already might have been deleted or unmounted)"
 	}
 
 	return fmt.Sprintf("%s %s %s",
-		humanize.Time(f.File.DeletedAt),
+		humanize.Time(f.DeletedAt),
 		bullet,
-		filepath.Dir(f.File.OriginalPath),
+		filepath.Dir(f.OriginalPath),
 	)
 }
 
 func (f File) Title() string {
-	fi, err := os.Stat(f.File.TrashPath)
+	fi, err := os.Stat(f.TrashPath)
 	if err != nil {
-		return f.File.Name + "?"
+		return f.Name + "?"
 	}
 	if fi.IsDir() {
-		return f.File.Name + "/"
+		return f.Name + "/"
 	}
-	return f.File.Name
+	return f.Name
 }
 
 func (f File) FilterValue() string {
-	return f.File.Name
+	return f.Name
 }
 
 func (f File) Size() string {
@@ -158,7 +158,7 @@ func (f File) colorize(content string) (string, error) {
 	var l chroma.Lexer
 	l = lexers.Get(f.Name)
 	if l == nil {
-		l = lexers.Analyse(content)
+		l = lexers.Analyse(content) //nolint:misspell // method name from chroma library
 	}
 	if l == nil {
 		slog.Debug("highlight: fallback to default lexer")

--- a/internal/ui/model.go
+++ b/internal/ui/model.go
@@ -1,15 +1,16 @@
 package ui
 
 import (
-	"github.com/babarot/gomi/internal/config"
-	"github.com/babarot/gomi/internal/trash"
-	"github.com/babarot/gomi/internal/ui/keys"
-	"github.com/babarot/gomi/internal/ui/styles"
 	"github.com/charmbracelet/bubbles/help"
 	"github.com/charmbracelet/bubbles/list"
 	"github.com/charmbracelet/bubbles/paginator"
 	"github.com/charmbracelet/bubbles/viewport"
 	"github.com/charmbracelet/lipgloss"
+
+	"github.com/babarot/gomi/internal/config"
+	"github.com/babarot/gomi/internal/trash"
+	"github.com/babarot/gomi/internal/ui/keys"
+	"github.com/babarot/gomi/internal/ui/styles"
 )
 
 // Model represents the main UI model following the Bubble Tea pattern
@@ -73,7 +74,7 @@ func NewModel(manager *trash.Manager, files []*trash.File, cfg *config.Config) M
 	l.SetShowTitle(false)
 	l.SetShowHelp(false) // do not use default help of list model
 	l.DisableQuitKeybindings()
-	
+
 	// Configure filter prompt style
 	l.FilterInput.PromptStyle = lipgloss.NewStyle().
 		Foreground(lipgloss.Color(cfg.UI.Style.ListView.FilterPrompt)).

--- a/internal/ui/styles/styles.go
+++ b/internal/ui/styles/styles.go
@@ -3,9 +3,10 @@ package styles
 import (
 	"strings"
 
-	"github.com/babarot/gomi/internal/config"
 	"github.com/charmbracelet/lipgloss"
 	"github.com/muesli/termenv"
+
+	"github.com/babarot/gomi/internal/config"
 )
 
 // Styles holds all UI styles for consistent theming

--- a/internal/ui/ui.go
+++ b/internal/ui/ui.go
@@ -4,9 +4,10 @@ import (
 	"errors"
 	"fmt"
 
+	tea "github.com/charmbracelet/bubbletea"
+
 	"github.com/babarot/gomi/internal/config"
 	"github.com/babarot/gomi/internal/trash"
-	tea "github.com/charmbracelet/bubbletea"
 )
 
 // ListDensityType represents the density of the list view
@@ -69,7 +70,10 @@ func Render(manager *trash.Manager, files []*trash.File, cfg *config.Config) ([]
 	}
 
 	// Process results
-	finalModel := result.(Model)
+	finalModel, ok := result.(Model)
+	if !ok {
+		return nil, fmt.Errorf("unexpected model type: %T", result)
+	}
 	if finalModel.state.current == Quitting {
 		if msg := cfg.UI.ExitMessage; msg != "" {
 			fmt.Println(msg)

--- a/internal/ui/update_test.go
+++ b/internal/ui/update_test.go
@@ -4,15 +4,26 @@ import (
 	"errors"
 	"testing"
 
-	"github.com/babarot/gomi/internal/config"
-	"github.com/babarot/gomi/internal/trash"
-	"github.com/babarot/gomi/internal/ui/keys"
-	"github.com/babarot/gomi/internal/ui/styles"
 	"github.com/charmbracelet/bubbles/help"
 	"github.com/charmbracelet/bubbles/list"
 	"github.com/charmbracelet/bubbles/viewport"
 	tea "github.com/charmbracelet/bubbletea"
+
+	"github.com/babarot/gomi/internal/config"
+	"github.com/babarot/gomi/internal/trash"
+	"github.com/babarot/gomi/internal/ui/keys"
+	"github.com/babarot/gomi/internal/ui/styles"
 )
+
+// asModel extracts Model from tea.Model with a fatal on type mismatch
+func asModel(t *testing.T, m tea.Model) Model {
+	t.Helper()
+	model, ok := m.(Model)
+	if !ok {
+		t.Fatalf("unexpected model type: %T", m)
+	}
+	return model
+}
 
 // newTestModel creates a minimal Model for testing Update logic
 func newTestModel() Model {
@@ -41,7 +52,7 @@ func TestUpdate_WindowSizeMsg(t *testing.T) {
 
 	msg := tea.WindowSizeMsg{Width: 120, Height: 40}
 	updated, _ := m.Update(msg)
-	model := updated.(Model)
+	model := asModel(t, updated)
 
 	if model.list.Width() != 120 {
 		t.Errorf("list width = %d, want 120", model.list.Width())
@@ -53,7 +64,7 @@ func TestUpdate_ErrorMsg(t *testing.T) {
 
 	msg := errorMsg{err: errors.New("test error")}
 	updated, cmd := m.Update(msg)
-	model := updated.(Model)
+	model := asModel(t, updated)
 
 	if model.state.current != Quitting {
 		t.Errorf("state = %v, want Quitting", model.state.current)
@@ -72,7 +83,7 @@ func TestUpdate_FileListLoadedMsg(t *testing.T) {
 	file := newTestFile("loaded.txt")
 	msg := FileListLoadedMsg{files: []list.Item{file}}
 	updated, _ := m.Update(msg)
-	model := updated.(Model)
+	model := asModel(t, updated)
 
 	items := model.list.Items()
 	if len(items) != 1 {
@@ -85,7 +96,7 @@ func TestUpdate_FileListLoadedMsg_Error(t *testing.T) {
 
 	msg := FileListLoadedMsg{err: errors.New("load failed")}
 	updated, cmd := m.Update(msg)
-	model := updated.(Model)
+	model := asModel(t, updated)
 
 	if model.err == nil {
 		t.Error("err should be set")
@@ -101,7 +112,7 @@ func TestUpdate_ListView_Quit(t *testing.T) {
 
 	msg := tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("q")}
 	updated, cmd := m.Update(msg)
-	model := updated.(Model)
+	model := asModel(t, updated)
 
 	if model.state.current != Quitting {
 		t.Errorf("state = %v, want Quitting", model.state.current)
@@ -117,7 +128,7 @@ func TestUpdate_ListView_CtrlC(t *testing.T) {
 
 	msg := tea.KeyMsg{Type: tea.KeyCtrlC}
 	updated, cmd := m.Update(msg)
-	model := updated.(Model)
+	model := asModel(t, updated)
 
 	if model.state.current != Quitting {
 		t.Errorf("state = %v, want Quitting", model.state.current)
@@ -133,7 +144,7 @@ func TestUpdate_DetailView_EscReturnsToList(t *testing.T) {
 
 	msg := tea.KeyMsg{Type: tea.KeyEsc}
 	updated, _ := m.Update(msg)
-	model := updated.(Model)
+	model := asModel(t, updated)
 
 	if model.state.current != ListView {
 		t.Errorf("state = %v, want ListView", model.state.current)
@@ -146,7 +157,7 @@ func TestUpdate_DetailView_Quit(t *testing.T) {
 
 	msg := tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("q")}
 	updated, cmd := m.Update(msg)
-	model := updated.(Model)
+	model := asModel(t, updated)
 
 	if model.state.current != Quitting {
 		t.Errorf("state = %v, want Quitting", model.state.current)
@@ -166,7 +177,7 @@ func TestUpdate_DetailView_AtSignToggles(t *testing.T) {
 
 	msg := tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("@")}
 	updated, _ := m.Update(msg)
-	model := updated.(Model)
+	model := asModel(t, updated)
 
 	if model.state.detail.dateFormat == initialDateFormat {
 		t.Error("date format should have toggled")
@@ -186,7 +197,7 @@ func TestUpdate_ConfirmView_YesNo_No(t *testing.T) {
 
 	msg := tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("n")}
 	updated, _ := m.Update(msg)
-	model := updated.(Model)
+	model := asModel(t, updated)
 
 	// Should go back to previous view
 	if model.state.current == ConfirmView {
@@ -203,7 +214,7 @@ func TestUpdate_ConfirmView_YesNo_Quit(t *testing.T) {
 
 	msg := tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("q")}
 	updated, cmd := m.Update(msg)
-	model := updated.(Model)
+	model := asModel(t, updated)
 
 	if model.state.current != Quitting {
 		t.Errorf("state = %v, want Quitting", model.state.current)
@@ -223,7 +234,7 @@ func TestUpdate_ConfirmView_TypeYES_Backspace(t *testing.T) {
 	// Type "Y"
 	msg := tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("Y")}
 	updated, _ := m.Update(msg)
-	m = updated.(Model)
+	m = asModel(t, updated)
 
 	if m.state.confirmation.yesInput != "Y" {
 		t.Errorf("yesInput = %q, want %q", m.state.confirmation.yesInput, "Y")
@@ -232,7 +243,7 @@ func TestUpdate_ConfirmView_TypeYES_Backspace(t *testing.T) {
 	// Backspace
 	msg = tea.KeyMsg{Type: tea.KeyBackspace}
 	updated, _ = m.Update(msg)
-	m = updated.(Model)
+	m = asModel(t, updated)
 
 	if m.state.confirmation.yesInput != "" {
 		t.Errorf("yesInput = %q, want empty after backspace", m.state.confirmation.yesInput)
@@ -248,7 +259,7 @@ func TestUpdate_ConfirmView_TypeYES_Esc(t *testing.T) {
 
 	msg := tea.KeyMsg{Type: tea.KeyEsc}
 	updated, _ := m.Update(msg)
-	model := updated.(Model)
+	model := asModel(t, updated)
 
 	if model.state.current == ConfirmView {
 		t.Error("esc should leave ConfirmView")
@@ -266,7 +277,7 @@ func TestUpdate_ListView_Enter_NoFiles(t *testing.T) {
 
 	msg := tea.KeyMsg{Type: tea.KeyEnter}
 	updated, cmd := m.Update(msg)
-	model := updated.(Model)
+	model := asModel(t, updated)
 
 	// With no selection manager items, it should pick the current item
 	if len(model.choices) != 1 {
@@ -288,7 +299,7 @@ func TestUpdate_ListView_Enter_WithSelection(t *testing.T) {
 
 	msg := tea.KeyMsg{Type: tea.KeyEnter}
 	updated, cmd := m.Update(msg)
-	model := updated.(Model)
+	model := asModel(t, updated)
 
 	if len(model.choices) != 2 {
 		t.Errorf("choices = %d, want 2", len(model.choices))
@@ -304,7 +315,7 @@ func TestUpdate_ShowDetailMsg(t *testing.T) {
 	file := File{File: &trash.File{Name: "detail.txt", TrashPath: "/trash/detail.txt"}}
 	msg := ShowDetailMsg{file: file}
 	updated, _ := m.Update(msg)
-	model := updated.(Model)
+	model := asModel(t, updated)
 
 	if model.state.current != DetailView {
 		t.Errorf("state = %v, want DetailView", model.state.current)

--- a/internal/ui/view.go
+++ b/internal/ui/view.go
@@ -3,11 +3,12 @@ package ui
 import (
 	"log/slog"
 
-	"github.com/babarot/gomi/internal/ui/keys"
 	"github.com/charmbracelet/bubbles/help"
 	"github.com/charmbracelet/bubbles/viewport"
 	"github.com/charmbracelet/lipgloss"
 	"github.com/fatih/color"
+
+	"github.com/babarot/gomi/internal/ui/keys"
 )
 
 // newHelpModel creates a help model with adaptive colors for light/dark terminals.

--- a/internal/ui/view_confirm.go
+++ b/internal/ui/view_confirm.go
@@ -59,12 +59,12 @@ func (m Model) formatConfirmation(files []File) string {
 func (m Model) formatConfirmationTypeYES(files []File) string {
 	// Display the current input state
 	const fullText = "YES"
-	var inputDisplay string
+	var inputDisplay strings.Builder
 
 	for i, char := range fullText {
 		if i < len(m.state.confirmation.yesInput) {
 			// Already typed characters shown in normal text
-			inputDisplay += m.styles.Confirm.Text.Render(string(m.state.confirmation.yesInput[i]))
+			inputDisplay.WriteString(m.styles.Confirm.Text.Render(string(m.state.confirmation.yesInput[i])))
 		} else {
 			// Not yet typed characters shown as placeholder
 			// instead of using a static underscore character for placeholders,
@@ -72,7 +72,7 @@ func (m Model) formatConfirmationTypeYES(files []File) string {
 			//
 			// inputDisplay += m.styles.Confirm.Placeholder.Render(string(char))
 			_ = char
-			inputDisplay += m.styles.Confirm.Placeholder.Render("_")
+			inputDisplay.WriteString(m.styles.Confirm.Placeholder.Render("_"))
 		}
 	}
 
@@ -109,7 +109,7 @@ func (m Model) formatConfirmationTypeYES(files []File) string {
 		"",
 		"Type YES to confirm",
 		"",
-		inputDisplay + statusIcon,
+		inputDisplay.String() + statusIcon,
 		"",
 		"  (ESC to cancel, Enter to confirm)  ",
 	}...)

--- a/internal/utils/debug/debug_test.go
+++ b/internal/utils/debug/debug_test.go
@@ -2,6 +2,7 @@ package debug
 
 import (
 	"bytes"
+	"errors"
 	"os"
 	"path/filepath"
 	"strings"
@@ -13,7 +14,9 @@ func TestShowExistingLogs(t *testing.T) {
 	logPath := filepath.Join(dir, "test.log")
 
 	content := "line1\nline2\nline3\n"
-	os.WriteFile(logPath, []byte(content), 0644)
+	if err := os.WriteFile(logPath, []byte(content), 0644); err != nil {
+		t.Fatal(err)
+	}
 
 	var buf bytes.Buffer
 	err := showExistingLogs(&buf, logPath)
@@ -36,7 +39,7 @@ func TestShowExistingLogs_NonExistent(t *testing.T) {
 	if err == nil {
 		t.Fatal("expected error for non-existent file")
 	}
-	if err != ErrLogFileNotFound {
+	if !errors.Is(err, ErrLogFileNotFound) {
 		t.Errorf("error = %v, want ErrLogFileNotFound", err)
 	}
 }
@@ -44,7 +47,9 @@ func TestShowExistingLogs_NonExistent(t *testing.T) {
 func TestShowExistingLogs_EmptyFile(t *testing.T) {
 	dir := t.TempDir()
 	logPath := filepath.Join(dir, "empty.log")
-	os.WriteFile(logPath, []byte(""), 0644)
+	if err := os.WriteFile(logPath, []byte(""), 0644); err != nil {
+		t.Fatal(err)
+	}
 
 	var buf bytes.Buffer
 	err := showExistingLogs(&buf, logPath)
@@ -59,7 +64,9 @@ func TestShowExistingLogs_EmptyFile(t *testing.T) {
 func TestLogs_FullMode(t *testing.T) {
 	dir := t.TempDir()
 	logPath := filepath.Join(dir, "test.log")
-	os.WriteFile(logPath, []byte("hello\nworld\n"), 0644)
+	if err := os.WriteFile(logPath, []byte("hello\nworld\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
 
 	var buf bytes.Buffer
 	err := Logs(&buf, logPath, false)
@@ -74,7 +81,7 @@ func TestLogs_FullMode(t *testing.T) {
 func TestLogs_NonExistent(t *testing.T) {
 	var buf bytes.Buffer
 	err := Logs(&buf, "/nonexistent/path.log", false)
-	if err != ErrLogFileNotFound {
+	if !errors.Is(err, ErrLogFileNotFound) {
 		t.Errorf("error = %v, want ErrLogFileNotFound", err)
 	}
 }

--- a/internal/utils/log/log.go
+++ b/internal/utils/log/log.go
@@ -57,7 +57,11 @@ func handler() *charmlog.Logger {
 }
 
 func loggerHandler(l *slog.Logger) *charmlog.Logger {
-	return l.Handler().(*charmlog.Logger)
+	h, ok := l.Handler().(*charmlog.Logger)
+	if !ok {
+		panic("unexpected logger handler type")
+	}
+	return h
 }
 
 // Logging methods

--- a/internal/utils/log/rotate_test.go
+++ b/internal/utils/log/rotate_test.go
@@ -111,7 +111,9 @@ func TestRotateWriter_RemoveOldFiles(t *testing.T) {
 
 	// Create some fake backup files
 	for _, suffix := range []string{".20240101-120000", ".20240102-120000", ".20240103-120000", ".20240104-120000"} {
-		os.WriteFile(path+suffix, []byte("old"), 0644)
+		if err := os.WriteFile(path+suffix, []byte("old"), 0644); err != nil {
+			t.Fatal(err)
+		}
 	}
 
 	rw, err := newRotateWriter(path, "1KB", 2)

--- a/internal/utils/shell/shell_test.go
+++ b/internal/utils/shell/shell_test.go
@@ -150,6 +150,6 @@ func BenchmarkExpandHome(b *testing.B) {
 
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		ExpandHome(input)
+		_, _ = ExpandHome(input)
 	}
 }


### PR DESCRIPTION
## WHAT

Introduce golangci-lint (v2) to the project with CI integration and fix all existing lint violations across the entire codebase (41 files, 339 insertions, 214 deletions).

## WHY

The gh-infra repository had a well-established linting setup that gomi was missing. Without automated linting, code quality issues like unchecked error returns, unsafe type assertions, and stale imports accumulate silently. This change closes the tooling gap between the two repositories and enforces consistent code quality going forward.

## Changes

### New files
- **`.golangci.yaml`** — golangci-lint v2 config enabling govet, staticcheck, errcheck (with `check-type-assertions: true`), unused, errorlint, misspell, revive, modernize, and goimports formatter
- **`.github/CODEOWNERS`** — `* @babarot` for automatic review assignment
- **`.github/workflows/build.yaml`** — Added `lint` job running `golangci/golangci-lint-action@v7`

### Makefile
- `make test` now outputs `coverage.out` via `-coverprofile`
- Added `make lint` target

### Lint fixes across source code (33 files)
- **errcheck**: All unchecked `os.WriteFile`, `os.MkdirAll`, `os.Symlink`, `json.Unmarshal`, `buf.ReadFrom` calls in tests now check errors with `t.Fatal`
- **errcheck (type assertions)**: Unsafe `.(Type)` casts replaced with `ok`-checked assertions in `log.go`, `ui.go`, `components.go`, `update_test.go`
- **errorlint**: `err.(validator.ValidationErrors)` and `err.(*os.PathError)` replaced with `errors.As`
- **modernize**: `strings.Split` loop → `slices.Contains`, `HasPrefix+TrimPrefix` → `strings.CutPrefix`, removed unnecessary loop variable copies, `if/else min/max` → `max()` builtin, `strings.Builder` usage
- **goimports**: Fixed import grouping and ordering across all files
- **unused**: Removed unused `getMountPoint` function from `mountpoint.go`
- **misspell**: Suppressed false positive on `lexers.Analyse` (chroma library method name)