### PR TITLE
Fix concurrency safety: eliminate global SelectionManager and add mutex to legacy Storage

### DIFF
--- a/internal/trash/legacy/storage.go
+++ b/internal/trash/legacy/storage.go
@@ -6,6 +6,7 @@ import (
 	"log/slog"
 	"os"
 	"path/filepath"
+	"sync"
 	"time"
 
 	"github.com/google/uuid"
@@ -17,6 +18,9 @@ import (
 
 // Storage implements the trash.Storage interface for legacy (.gomi) storage
 type Storage struct {
+	// mu protects history access for concurrent Put/Restore/Remove calls
+	mu sync.Mutex
+
 	// Root directory for trash storage (~/.gomi)
 	root string
 
@@ -98,7 +102,8 @@ func (s *Storage) Put(src string) error {
 		return trash.NewStorageError("put", src, err)
 	}
 
-	// Add to history
+	// Add to history (protected by mutex for concurrent Put calls)
+	s.mu.Lock()
 	s.history.Add(history.File{
 		Name:      filepath.Base(abs),
 		ID:        id,
@@ -110,6 +115,7 @@ func (s *Storage) Put(src string) error {
 
 	// Save history
 	if err := s.saveHistory(); err != nil {
+		s.mu.Unlock()
 		// Try to roll back the file move
 		if moveErr := fs.Move(trashPath, abs, true); moveErr != nil {
 			return trash.NewStorageError(
@@ -122,14 +128,19 @@ func (s *Storage) Put(src string) error {
 			src,
 			fmt.Errorf("failed to save history: %w", err))
 	}
+	s.mu.Unlock()
 
 	return nil
 }
 
 func (s *Storage) List() ([]*trash.File, error) {
+	s.mu.Lock()
+	filtered := s.history.Filter()
+	s.mu.Unlock()
+
 	var files []*trash.File
 
-	for _, f := range s.history.Filter() {
+	for _, f := range filtered {
 		// Convert legacy File to trash.File
 		file := &trash.File{
 			Name:         f.Name,
@@ -167,13 +178,14 @@ func (s *Storage) Restore(file *trash.File, dst string) error {
 		return trash.NewStorageError("restore", dst, err)
 	}
 
-	// Remove from history
+	// Remove from history (protected by mutex)
+	s.mu.Lock()
 	s.history.RemoveByPath(file.TrashPath)
-
-	// Save history
 	if err := s.saveHistory(); err != nil {
+		s.mu.Unlock()
 		return trash.NewStorageError("restore", dst, fmt.Errorf("failed to save history: %w", err))
 	}
+	s.mu.Unlock()
 
 	return nil
 }
@@ -184,13 +196,14 @@ func (s *Storage) Remove(file *trash.File) error {
 		return trash.NewStorageError("remove", file.TrashPath, err)
 	}
 
-	// Remove from history
+	// Remove from history (protected by mutex)
+	s.mu.Lock()
 	s.history.RemoveByPath(file.TrashPath)
-
-	// Save history
 	if err := s.saveHistory(); err != nil {
+		s.mu.Unlock()
 		return trash.NewStorageError("remove", file.TrashPath, fmt.Errorf("failed to save history: %w", err))
 	}
+	s.mu.Unlock()
 
 	return nil
 }

--- a/internal/ui/delegate.go
+++ b/internal/ui/delegate.go
@@ -110,13 +110,14 @@ type RestoreDelegate struct {
 	ShortHelpFunc func() []key.Binding
 	FullHelpFunc  func() [][]key.Binding
 
+	selection       *SelectionManager
 	showDescription bool
 	height          int
 	spacing         int
 }
 
 // NewRestoreDelegate creates a new delegate with Restore styles.
-func NewRestoreDelegate(cfg config.UI, files []File) RestoreDelegate {
+func NewRestoreDelegate(cfg config.UI, files []File, selection *SelectionManager) RestoreDelegate {
 	var height = 2
 	var spacing = 1
 
@@ -134,6 +135,7 @@ func NewRestoreDelegate(cfg config.UI, files []File) RestoreDelegate {
 	}
 
 	return RestoreDelegate{
+		selection:       selection,
 		showDescription: showDescription,
 		Styles:          NewRestoreItemStyles(cfg),
 		height:          height,
@@ -213,14 +215,14 @@ func (d RestoreDelegate) Render(w io.Writer, m list.Model, index int, item list.
 			matched := unmatched.Inherit(s.FilterMatch)
 			title = lipgloss.StyleRunes(title, matchedRunes, matched, unmatched)
 		}
-		if file.isSelected() {
+		if d.selection.Contains(file) {
 			title = s.SelectedCursorTitle.Render(title)
 			desc = s.SelectedCursorDesc.Render(desc)
 		} else {
 			title = s.CursorTitle.Render(title)
 			desc = s.CursorDesc.Render(desc)
 		}
-	} else if file.isSelected() {
+	} else if d.selection.Contains(file) {
 		title = s.SelectedTitle.Render(title)
 		desc = s.SelectedDesc.Render(desc)
 	} else {

--- a/internal/ui/file.go
+++ b/internal/ui/file.go
@@ -37,10 +37,6 @@ type File struct {
 	colorscheme     string
 }
 
-func (f File) isSelected() bool {
-	return selectionManager.Contains(f)
-}
-
 func (f File) Description() string {
 	_, err := os.Stat(f.TrashPath)
 	if os.IsNotExist(err) {

--- a/internal/ui/model.go
+++ b/internal/ui/model.go
@@ -31,6 +31,9 @@ type Model struct {
 	files   []File
 	choices []File
 
+	// Selection tracking
+	selection *SelectionManager
+
 	// UI components and config
 	config   config.UI
 	help     help.Model
@@ -63,8 +66,11 @@ func NewModel(manager *trash.Manager, files []*trash.File, cfg *config.Config) M
 		DeleteEnabled: cfg.Core.PermanentDelete.Enable,
 	})
 
+	// Initialize selection manager
+	selection := &SelectionManager{items: []File{}}
+
 	// Initialize list delegate
-	delegate := NewRestoreDelegate(cfg.UI, fileList)
+	delegate := NewRestoreDelegate(cfg.UI, fileList, selection)
 	delegate.ShortHelpFunc = keyMap.AsListKeyMap().ShortHelp
 	delegate.FullHelpFunc = keyMap.AsListKeyMap().FullHelp
 
@@ -93,6 +99,7 @@ func NewModel(manager *trash.Manager, files []*trash.File, cfg *config.Config) M
 		trashManager: manager,
 		state:        NewViewState(),
 		keyMap:       keyMap,
+		selection:    selection,
 		files:        fileList,
 		config:       cfg.UI,
 		list:         l,

--- a/internal/ui/selection_manager.go
+++ b/internal/ui/selection_manager.go
@@ -1,9 +1,6 @@
 package ui
 
-var (
-	selectionManager = &SelectionManager{items: []File{}}
-)
-
+// SelectionManager tracks which files the user has selected for restoration
 type SelectionManager struct {
 	items []File
 }

--- a/internal/ui/update.go
+++ b/internal/ui/update.go
@@ -80,7 +80,7 @@ func (m Model) updateListView(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 
 	case m.keyMap.List.Delete != nil && key.Matches(msg, *m.keyMap.List.Delete):
 		if m.list.FilterState() != list.Filtering {
-			files := selectionManager.items
+			files := m.selection.items
 			switch len(files) {
 			case 0:
 				file, ok := m.list.SelectedItem().(File)
@@ -104,10 +104,10 @@ func (m Model) updateListView(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 			if !ok {
 				return m, nil
 			}
-			if item.isSelected() {
-				selectionManager.Remove(item)
+			if m.selection.Contains(item) {
+				m.selection.Remove(item)
 			} else {
-				selectionManager.Add(item)
+				m.selection.Add(item)
 			}
 			m.list.CursorDown()
 		}
@@ -119,8 +119,8 @@ func (m Model) updateListView(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 			if !ok {
 				return m, nil
 			}
-			if item.isSelected() {
-				selectionManager.Remove(item)
+			if m.selection.Contains(item) {
+				m.selection.Remove(item)
 			}
 			m.list.CursorUp()
 		}
@@ -137,8 +137,8 @@ func (m Model) updateListView(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 
 	case key.Matches(msg, m.keyMap.List.Esc):
 		if m.list.FilterState() != list.Filtering {
-			if len(selectionManager.items) > 0 {
-				selectionManager = &SelectionManager{items: []File{}}
+			if len(m.selection.items) > 0 {
+				m.selection = &SelectionManager{items: []File{}}
 				return m, nil
 			}
 		}
@@ -147,7 +147,7 @@ func (m Model) updateListView(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 
 	case key.Matches(msg, m.keyMap.List.Enter):
 		if m.list.FilterState() != list.Filtering {
-			files := selectionManager.items
+			files := m.selection.items
 			if len(files) == 0 {
 				file, ok := m.list.SelectedItem().(File)
 				if ok {
@@ -252,7 +252,7 @@ func (m Model) updateDetailView(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 
 // updateConfirmView handles updates specific to the confirmation dialog
 func (m Model) updateConfirmView(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
-	files := selectionManager.items
+	files := m.selection.items
 
 	// Branch processing based on ConfirmState
 	if m.state.confirmation.state == ConfirmStateTypeYES {

--- a/internal/ui/update_test.go
+++ b/internal/ui/update_test.go
@@ -37,13 +37,14 @@ func newTestModel() Model {
 	l.DisableQuitKeybindings()
 
 	return Model{
-		state:    NewViewState(),
-		keyMap:   km,
-		config:   cfg.UI,
-		list:     l,
-		viewport: viewport.Model{},
-		styles:   styles.New(cfg.UI),
-		help:     help.New(),
+		state:     NewViewState(),
+		keyMap:    km,
+		selection: &SelectionManager{items: []File{}},
+		config:    cfg.UI,
+		list:      l,
+		viewport:  viewport.Model{},
+		styles:    styles.New(cfg.UI),
+		help:      help.New(),
 	}
 }
 
@@ -190,7 +191,7 @@ func TestUpdate_DetailView_AtSignToggles(t *testing.T) {
 func TestUpdate_ConfirmView_YesNo_No(t *testing.T) {
 	m := newTestModel()
 	// Reset global selection manager for test isolation
-	selectionManager = &SelectionManager{items: []File{}}
+	m.selection = &SelectionManager{items: []File{}}
 
 	m.state.SetView(ConfirmView)
 	m.state.SetConfirmState(ConfirmStateYesNo, []File{})
@@ -207,7 +208,7 @@ func TestUpdate_ConfirmView_YesNo_No(t *testing.T) {
 
 func TestUpdate_ConfirmView_YesNo_Quit(t *testing.T) {
 	m := newTestModel()
-	selectionManager = &SelectionManager{items: []File{}}
+	m.selection = &SelectionManager{items: []File{}}
 
 	m.state.SetView(ConfirmView)
 	m.state.SetConfirmState(ConfirmStateYesNo, []File{})
@@ -226,7 +227,7 @@ func TestUpdate_ConfirmView_YesNo_Quit(t *testing.T) {
 
 func TestUpdate_ConfirmView_TypeYES_Backspace(t *testing.T) {
 	m := newTestModel()
-	selectionManager = &SelectionManager{items: []File{}}
+	m.selection = &SelectionManager{items: []File{}}
 
 	m.state.SetView(ConfirmView)
 	m.state.SetConfirmState(ConfirmStateTypeYES, []File{})
@@ -252,7 +253,7 @@ func TestUpdate_ConfirmView_TypeYES_Backspace(t *testing.T) {
 
 func TestUpdate_ConfirmView_TypeYES_Esc(t *testing.T) {
 	m := newTestModel()
-	selectionManager = &SelectionManager{items: []File{}}
+	m.selection = &SelectionManager{items: []File{}}
 
 	m.state.SetView(ConfirmView)
 	m.state.SetConfirmState(ConfirmStateTypeYES, []File{})
@@ -268,7 +269,7 @@ func TestUpdate_ConfirmView_TypeYES_Esc(t *testing.T) {
 
 func TestUpdate_ListView_Enter_NoFiles(t *testing.T) {
 	m := newTestModel()
-	selectionManager = &SelectionManager{items: []File{}}
+	m.selection = &SelectionManager{items: []File{}}
 	m.state.SetView(ListView)
 
 	// Add an item to the list so SelectedItem works
@@ -293,7 +294,7 @@ func TestUpdate_ListView_Enter_WithSelection(t *testing.T) {
 
 	f1 := newTestFile("a.txt")
 	f2 := newTestFile("b.txt")
-	selectionManager = &SelectionManager{items: []File{f1, f2}}
+	m.selection = &SelectionManager{items: []File{f1, f2}}
 	m.state.SetView(ListView)
 	m.list.SetItems([]list.Item{f1, f2})
 

--- a/internal/ui/view_detail.go
+++ b/internal/ui/view_detail.go
@@ -27,7 +27,7 @@ func (m Model) renderHeader() string {
 	return m.styles.RenderDetailTitle(
 		m.detailFile.Title(),
 		defaultWidth,
-		m.detailFile.isSelected(),
+		m.selection.Contains(m.detailFile),
 	)
 }
 


### PR DESCRIPTION

## WHAT

Remove the global `selectionManager` variable from the UI package by moving it to a `Model` field, and add `sync.Mutex` to legacy storage to protect concurrent history access.

## WHY

A comprehensive code review identified two safety issues:

1. **Global SelectionManager** — The package-level `var selectionManager` leaked state between tests and violated dependency injection principles. Any future parallelism in BubbleTea updates would also create a data race.

2. **Unprotected legacy history** — `cli/put.go` uses `errgroup` to trash multiple files concurrently, which calls `Storage.Put()` in parallel. Without synchronization, concurrent `history.Add()` + `saveHistory()` calls could corrupt the in-memory history slice or produce partial file writes.

