### PR TITLE
Refactor: extract Trash interface, move orphan logic, and DRY up XDG storage

### DIFF
--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -62,7 +62,7 @@ type CLI struct {
 	option  Option
 	config  *config.Config
 	runID   string
-	manager *trash.Manager
+	manager trash.Trash
 }
 
 var runID = sync.OnceValue(func() string {

--- a/internal/cli/cli_test.go
+++ b/internal/cli/cli_test.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/babarot/gomi/internal/config"
 	"github.com/babarot/gomi/internal/trash"
+	"github.com/babarot/gomi/internal/trash/xdg"
 	"github.com/babarot/gomi/internal/utils/log"
 )
 
@@ -295,50 +296,6 @@ func TestPrune_EmptyArg(t *testing.T) {
 	}
 }
 
-func TestParseTrashInfoFile(t *testing.T) {
-	dir := t.TempDir()
-	infoFile := filepath.Join(dir, "test.trashinfo")
-
-	content := "[Trash Info]\nPath=/home/user/test.txt\nDeletionDate=2024-06-15T10:30:00\n"
-	if err := os.WriteFile(infoFile, []byte(content), 0644); err != nil {
-		t.Fatal(err)
-	}
-
-	orphan, err := parseTrashInfoFile(infoFile)
-	if err != nil {
-		t.Fatalf("parseTrashInfoFile() error = %v", err)
-	}
-	if orphan.OriginalPath != "/home/user/test.txt" {
-		t.Errorf("OriginalPath = %q, want %q", orphan.OriginalPath, "/home/user/test.txt")
-	}
-	if orphan.DeletedAt.Year() != 2024 || orphan.DeletedAt.Month() != 6 || orphan.DeletedAt.Day() != 15 {
-		t.Errorf("DeletedAt = %v, unexpected", orphan.DeletedAt)
-	}
-	if orphan.TrashInfoPath != infoFile {
-		t.Errorf("TrashInfoPath = %q, want %q", orphan.TrashInfoPath, infoFile)
-	}
-}
-
-func TestParseTrashInfoFile_InvalidDate(t *testing.T) {
-	dir := t.TempDir()
-	infoFile := filepath.Join(dir, "bad.trashinfo")
-	if err := os.WriteFile(infoFile, []byte("Path=/foo\nDeletionDate=not-a-date\n"), 0644); err != nil {
-		t.Fatal(err)
-	}
-
-	_, err := parseTrashInfoFile(infoFile)
-	if err == nil {
-		t.Error("expected error for invalid date")
-	}
-}
-
-func TestParseTrashInfoFile_NonExistent(t *testing.T) {
-	_, err := parseTrashInfoFile("/nonexistent/file.trashinfo")
-	if err == nil {
-		t.Error("expected error for non-existent file")
-	}
-}
-
 func TestPruneArgs_UnmarshalFlag(t *testing.T) {
 	var p PruneArgs
 	if err := p.UnmarshalFlag("30d,orphans"); err != nil {
@@ -353,7 +310,7 @@ func TestPruneArgs_UnmarshalFlag(t *testing.T) {
 }
 
 func TestOrphanedFile_Getters(t *testing.T) {
-	o := OrphanedFile{
+	o := xdg.OrphanedFile{
 		TrashInfoName: "test.trashinfo",
 	}
 	if o.GetName() != "test.trashinfo" {

--- a/internal/cli/prune.go
+++ b/internal/cli/prune.go
@@ -5,8 +5,6 @@ import (
 	"fmt"
 	"log/slog"
 	"os"
-	"path/filepath"
-	"strings"
 	"time"
 
 	"github.com/fatih/color"
@@ -30,18 +28,6 @@ var (
 	ErrInvalidDurationNum  = errors.New("duration must be a positive number")
 	ErrInvalidDurationUnit = errors.New("unsupported duration unit")
 )
-
-// OrphanedFile represents an orphaned metadata file with additional details
-type OrphanedFile struct {
-	Path          string
-	DeletedAt     time.Time
-	OriginalPath  string
-	TrashInfoPath string
-	TrashInfoName string
-}
-
-func (o OrphanedFile) GetName() string         { return o.TrashInfoName }
-func (o OrphanedFile) GetDeletedAt() time.Time { return o.DeletedAt }
 
 // Prune handles the pruning of trash contents
 // It processes multiple subcommands for cleaning up the trash
@@ -75,49 +61,6 @@ func (c *CLI) Prune(args []string) error {
 		durations = append(durations, duration)
 	}
 	return c.permanentlyDeleteByTimeRange(durations)
-}
-
-// findOrphanedTrashInfoFiles finds .trashinfo files without corresponding files
-// Returns a list of paths to orphaned .trashinfo files
-func findOrphanedTrashInfoFiles(trashDir string) ([]OrphanedFile, error) {
-	infoDir := filepath.Join(trashDir, "info")
-	filesDir := filepath.Join(trashDir, "files")
-
-	var orphanedFiles []OrphanedFile
-
-	entries, err := os.ReadDir(infoDir)
-	if err != nil {
-		return nil, fmt.Errorf("failed to read info directory: %w", err)
-	}
-
-	for _, entry := range entries {
-		// Skip non-regular files and non-.trashinfo files
-		if !entry.Type().IsRegular() || !strings.HasSuffix(entry.Name(), ".trashinfo") {
-			continue
-		}
-
-		if strings.HasPrefix(entry.Name(), "._") {
-			// exclude mac resource fork
-			slog.Debug("skipped mac resource fork of .trashinfo", "path", entry.Name())
-			continue
-		}
-
-		// Remove .trashinfo suffix to get the corresponding file name
-		fileName := strings.TrimSuffix(entry.Name(), ".trashinfo")
-		trashInfoPath := filepath.Join(infoDir, entry.Name())
-
-		// Check if corresponding file exists in files directory
-		_, err := os.Stat(filepath.Join(filesDir, fileName))
-		if os.IsNotExist(err) {
-			metadata, parseErr := parseTrashInfoFile(trashInfoPath)
-			if parseErr != nil {
-				continue
-			}
-			orphanedFiles = append(orphanedFiles, metadata)
-		}
-	}
-
-	return orphanedFiles, nil
 }
 
 // permanentlyDeleteByTimeRange removes files from trash based on their age.
@@ -240,10 +183,10 @@ func (c *CLI) removeOrphanedMetadata() error {
 		return fmt.Errorf("failed to get trash dirs: %w", err)
 	}
 
-	var orphanedFiles []OrphanedFile
+	var orphanedFiles []xdg.OrphanedFile
 	for _, trashDir := range trashDirs {
 		slog.Debug("pruning orphaned trashinfo", "trashDir", trashDir)
-		files, err := findOrphanedTrashInfoFiles(trashDir)
+		files, err := xdg.FindOrphanedTrashInfoFiles(trashDir)
 		if err != nil {
 			slog.Error("failed to find orphaned metadata in trash dir", "dir", trashDir, "error", err)
 			continue
@@ -290,36 +233,4 @@ func (c *CLI) removeOrphanedMetadata() error {
 
 	fmt.Printf("Successfully removed %d orphaned metadata files.\n", len(orphanedFiles))
 	return nil
-}
-
-// parseTrashInfoFile parses a .trashinfo file and returns an OrphanedFile
-func parseTrashInfoFile(path string) (OrphanedFile, error) {
-	content, err := os.ReadFile(path)
-	if err != nil {
-		return OrphanedFile{}, err
-	}
-
-	lines := strings.Split(string(content), "\n")
-	var deletedAt time.Time
-	var originalPath string
-
-	for _, line := range lines {
-		if after, ok := strings.CutPrefix(line, "Path="); ok {
-			originalPath = after
-		}
-		if after, ok := strings.CutPrefix(line, "DeletionDate="); ok {
-			deletedAtStr := after
-			deletedAt, err = time.Parse("2006-01-02T15:04:05", deletedAtStr)
-			if err != nil {
-				return OrphanedFile{}, err
-			}
-		}
-	}
-
-	return OrphanedFile{
-		DeletedAt:     deletedAt,
-		OriginalPath:  originalPath,
-		TrashInfoPath: path,
-		TrashInfoName: filepath.Base(path),
-	}, nil
 }

--- a/internal/trash/manager.go
+++ b/internal/trash/manager.go
@@ -28,6 +28,15 @@ const (
 	StrategyNone Strategy = ""
 )
 
+// Trash defines the interface for trash operations.
+// It is implemented by Manager and can be mocked in tests.
+type Trash interface {
+	Put(src string) error
+	List() ([]*File, error)
+	Restore(file *File, dst string) error
+	Remove(file *File) error
+}
+
 // Manager handles multiple trash storage implementations
 type Manager struct {
 	storages []Storage

--- a/internal/trash/xdg/orphan.go
+++ b/internal/trash/xdg/orphan.go
@@ -1,0 +1,96 @@
+package xdg
+
+import (
+	"fmt"
+	"log/slog"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+)
+
+// OrphanedFile represents an orphaned metadata file with additional details
+type OrphanedFile struct {
+	Path          string
+	DeletedAt     time.Time
+	OriginalPath  string
+	TrashInfoPath string
+	TrashInfoName string
+}
+
+func (o OrphanedFile) GetName() string         { return o.TrashInfoName }
+func (o OrphanedFile) GetDeletedAt() time.Time { return o.DeletedAt }
+
+// FindOrphanedTrashInfoFiles finds .trashinfo files without corresponding files
+// Returns a list of paths to orphaned .trashinfo files
+func FindOrphanedTrashInfoFiles(trashDir string) ([]OrphanedFile, error) {
+	infoDir := filepath.Join(trashDir, "info")
+	filesDir := filepath.Join(trashDir, "files")
+
+	var orphanedFiles []OrphanedFile
+
+	entries, err := os.ReadDir(infoDir)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read info directory: %w", err)
+	}
+
+	for _, entry := range entries {
+		// Skip non-regular files and non-.trashinfo files
+		if !entry.Type().IsRegular() || !strings.HasSuffix(entry.Name(), ".trashinfo") {
+			continue
+		}
+
+		if strings.HasPrefix(entry.Name(), "._") {
+			// exclude mac resource fork
+			slog.Debug("skipped mac resource fork of .trashinfo", "path", entry.Name())
+			continue
+		}
+
+		// Remove .trashinfo suffix to get the corresponding file name
+		fileName := strings.TrimSuffix(entry.Name(), ".trashinfo")
+		trashInfoPath := filepath.Join(infoDir, entry.Name())
+
+		// Check if corresponding file exists in files directory
+		_, err := os.Stat(filepath.Join(filesDir, fileName))
+		if os.IsNotExist(err) {
+			metadata, parseErr := ParseTrashInfoFile(trashInfoPath)
+			if parseErr != nil {
+				continue
+			}
+			orphanedFiles = append(orphanedFiles, metadata)
+		}
+	}
+
+	return orphanedFiles, nil
+}
+
+// ParseTrashInfoFile parses a .trashinfo file and returns an OrphanedFile
+func ParseTrashInfoFile(path string) (OrphanedFile, error) {
+	content, err := os.ReadFile(path)
+	if err != nil {
+		return OrphanedFile{}, err
+	}
+
+	lines := strings.Split(string(content), "\n")
+	var deletedAt time.Time
+	var originalPath string
+
+	for _, line := range lines {
+		if after, ok := strings.CutPrefix(line, "Path="); ok {
+			originalPath = after
+		}
+		if after, ok := strings.CutPrefix(line, "DeletionDate="); ok {
+			deletedAt, err = time.Parse("2006-01-02T15:04:05", after)
+			if err != nil {
+				return OrphanedFile{}, err
+			}
+		}
+	}
+
+	return OrphanedFile{
+		DeletedAt:     deletedAt,
+		OriginalPath:  originalPath,
+		TrashInfoPath: path,
+		TrashInfoName: filepath.Base(path),
+	}, nil
+}

--- a/internal/trash/xdg/orphan_test.go
+++ b/internal/trash/xdg/orphan_test.go
@@ -1,0 +1,51 @@
+package xdg
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestParseTrashInfoFile(t *testing.T) {
+	dir := t.TempDir()
+	infoFile := filepath.Join(dir, "test.trashinfo")
+
+	content := "[Trash Info]\nPath=/home/user/test.txt\nDeletionDate=2024-06-15T10:30:00\n"
+	if err := os.WriteFile(infoFile, []byte(content), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	orphan, err := ParseTrashInfoFile(infoFile)
+	if err != nil {
+		t.Fatalf("ParseTrashInfoFile() error = %v", err)
+	}
+	if orphan.OriginalPath != "/home/user/test.txt" {
+		t.Errorf("OriginalPath = %q, want %q", orphan.OriginalPath, "/home/user/test.txt")
+	}
+	if orphan.DeletedAt.Year() != 2024 || orphan.DeletedAt.Month() != 6 || orphan.DeletedAt.Day() != 15 {
+		t.Errorf("DeletedAt = %v, unexpected", orphan.DeletedAt)
+	}
+	if orphan.TrashInfoPath != infoFile {
+		t.Errorf("TrashInfoPath = %q, want %q", orphan.TrashInfoPath, infoFile)
+	}
+}
+
+func TestParseTrashInfoFile_InvalidDate(t *testing.T) {
+	dir := t.TempDir()
+	infoFile := filepath.Join(dir, "bad.trashinfo")
+	if err := os.WriteFile(infoFile, []byte("Path=/foo\nDeletionDate=not-a-date\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	_, err := ParseTrashInfoFile(infoFile)
+	if err == nil {
+		t.Error("expected error for invalid date")
+	}
+}
+
+func TestParseTrashInfoFile_NonExistent(t *testing.T) {
+	_, err := ParseTrashInfoFile("/nonexistent/file.trashinfo")
+	if err == nil {
+		t.Error("expected error for non-existent file")
+	}
+}

--- a/internal/trash/xdg/storage.go
+++ b/internal/trash/xdg/storage.go
@@ -182,15 +182,8 @@ func (s *Storage) Restore(file *trash.File, dst string) error {
 	}
 
 	// Remove .trashinfo file
-	infoBaseName := filepath.Base(file.TrashPath) + ".trashinfo"
-	infoPath := filepath.Join(
-		filepath.Dir(filepath.Dir(file.TrashPath)), // Go up two levels (past "files" dir)
-		"info",
-		infoBaseName,
-	)
-	if err := os.Remove(infoPath); err != nil {
-		// Log error but don't fail - file is already restored
-		fmt.Fprintf(os.Stderr, "Warning: failed to remove trash info: %v\n", err)
+	if err := os.Remove(infoPathForFile(file.TrashPath)); err != nil {
+		slog.Warn("failed to remove trash info", "error", err)
 	}
 
 	return nil
@@ -203,18 +196,21 @@ func (s *Storage) Remove(file *trash.File) error {
 	}
 
 	// Remove .trashinfo file
-	infoBaseName := filepath.Base(file.TrashPath) + ".trashinfo"
-	infoPath := filepath.Join(
-		filepath.Dir(filepath.Dir(file.TrashPath)), // Go up two levels (past "files" dir)
-		"info",
-		infoBaseName,
-	)
-	if err := os.Remove(infoPath); err != nil {
-		// Log error but don't fail - file is already removed
-		fmt.Fprintf(os.Stderr, "Warning: failed to remove trash info: %v\n", err)
+	if err := os.Remove(infoPathForFile(file.TrashPath)); err != nil {
+		slog.Warn("failed to remove trash info", "error", err)
 	}
 
 	return nil
+}
+
+// infoPathForFile returns the .trashinfo file path for a given trash file path.
+// Given a path like /trash/files/foo.txt, it returns /trash/info/foo.txt.trashinfo.
+func infoPathForFile(trashPath string) string {
+	return filepath.Join(
+		filepath.Dir(filepath.Dir(trashPath)), // Go up two levels (past "files" dir)
+		"info",
+		filepath.Base(trashPath)+".trashinfo",
+	)
 }
 
 func (s *Storage) initHomeTrash() (*trashLocation, error) {

--- a/internal/ui/model.go
+++ b/internal/ui/model.go
@@ -16,7 +16,7 @@ import (
 // Model represents the main UI model following the Bubble Tea pattern
 type Model struct {
 	// Manager handles trash operations
-	trashManager *trash.Manager
+	trashManager trash.Trash
 
 	// State management
 	state *ViewState
@@ -46,7 +46,7 @@ type Model struct {
 }
 
 // NewModel creates a new UI model instance
-func NewModel(manager *trash.Manager, files []*trash.File, cfg *config.Config) Model {
+func NewModel(manager trash.Trash, files []*trash.File, cfg *config.Config) Model {
 	var items []list.Item
 	var fileList []File
 

--- a/internal/ui/ui.go
+++ b/internal/ui/ui.go
@@ -56,7 +56,7 @@ func (m Model) Init() tea.Cmd {
 }
 
 // Render displays the file selection interface and returns the selected files
-func Render(manager *trash.Manager, files []*trash.File, cfg *config.Config) ([]*trash.File, error) {
+func Render(manager trash.Trash, files []*trash.File, cfg *config.Config) ([]*trash.File, error) {
 	// Create and initialize the model
 	m := NewModel(manager, files, cfg)
 


### PR DESCRIPTION
## WHAT

Structural improvements across the trash management codebase: extract a `Trash` interface for mockability, relocate XDG-specific domain logic from CLI to its proper package, and eliminate code duplication in XDG storage operations.

## WHY

A comprehensive code review identified three structural issues:
1. CLI and UI depended on the concrete `*trash.Manager` type, making mock-based testing impossible
2. Orphan detection logic (`findOrphanedTrashInfoFiles`, `parseTrashInfoFile`, `OrphanedFile`) was XDG-specific domain logic incorrectly placed in the CLI package
3. `Restore()` and `Remove()` in XDG storage had identical `.trashinfo` path reconstruction code

This PR also includes Phase 1 safety fixes (SelectionManager global removal + legacy Storage mutex) since those aren't merged yet.