### PR TITLE
Refactor: decouple config, remove unused fields, and narrow UI dependencies

### DIFF
--- a/internal/cli/restore.go
+++ b/internal/cli/restore.go
@@ -35,7 +35,10 @@ func (c *CLI) Restore() error {
 	}
 
 	// Show UI for file selection
-	selected, err := ui.Render(c.manager, filtered, c.config)
+	selected, err := ui.Render(c.manager, filtered, ui.RenderOptions{
+		Config:        c.config.UI,
+		DeleteEnabled: c.config.Core.PermanentDelete.Enable,
+	})
 	if err != nil {
 		return fmt.Errorf("failed to show file selection UI: %w", err)
 	}

--- a/internal/trash/config.go
+++ b/internal/trash/config.go
@@ -35,15 +35,6 @@ type Config struct {
 	// ForceHomeTrash forces using home trash even for external devices
 	ForceHomeTrash bool
 
-	// SkipMountPointFind skips finding mount points for external trash dirs
-	SkipMountPointFind bool
-
-	// PreservePaths preserves original path structure in trash
-	PreservePaths bool
-
-	// UseCompression enables compression for trashed files
-	UseCompression bool
-
 	// History contains history-related configuration
 	History config.History
 

--- a/internal/ui/model.go
+++ b/internal/ui/model.go
@@ -46,31 +46,33 @@ type Model struct {
 }
 
 // NewModel creates a new UI model instance
-func NewModel(manager trash.Trash, files []*trash.File, cfg *config.Config) Model {
+func NewModel(manager trash.Trash, files []*trash.File, opts RenderOptions) Model {
 	var items []list.Item
 	var fileList []File
+
+	uiCfg := opts.Config
 
 	// Convert trash files to UI files
 	for _, file := range files {
 		items = append(items, File{File: file})
 		fileList = append(fileList, File{
 			File:            file,
-			dirListCommand:  cfg.UI.Preview.DirectoryCommand,
-			syntaxHighlight: cfg.UI.Preview.SyntaxHighlight,
-			colorscheme:     cfg.UI.Preview.Colorscheme,
+			dirListCommand:  uiCfg.Preview.DirectoryCommand,
+			syntaxHighlight: uiCfg.Preview.SyntaxHighlight,
+			colorscheme:     uiCfg.Preview.Colorscheme,
 		})
 	}
 
 	// Initialize key map
 	keyMap := keys.NewKeyMap(keys.KeyMapConfig{
-		DeleteEnabled: cfg.Core.PermanentDelete.Enable,
+		DeleteEnabled: opts.DeleteEnabled,
 	})
 
 	// Initialize selection manager
 	selection := &SelectionManager{items: []File{}}
 
 	// Initialize list delegate
-	delegate := NewRestoreDelegate(cfg.UI, fileList, selection)
+	delegate := NewRestoreDelegate(uiCfg, fileList, selection)
 	delegate.ShortHelpFunc = keyMap.AsListKeyMap().ShortHelp
 	delegate.FullHelpFunc = keyMap.AsListKeyMap().FullHelp
 
@@ -83,11 +85,11 @@ func NewModel(manager trash.Trash, files []*trash.File, cfg *config.Config) Mode
 
 	// Configure filter prompt style
 	l.FilterInput.PromptStyle = lipgloss.NewStyle().
-		Foreground(lipgloss.Color(cfg.UI.Style.ListView.FilterPrompt)).
+		Foreground(lipgloss.Color(uiCfg.Style.ListView.FilterPrompt)).
 		Bold(true)
 
 	// Set paginator type based on config
-	switch cfg.UI.Paginator {
+	switch uiCfg.Paginator {
 	case PaginatorArabic:
 		l.Paginator.Type = paginator.Arabic
 	default:
@@ -101,10 +103,10 @@ func NewModel(manager trash.Trash, files []*trash.File, cfg *config.Config) Mode
 		keyMap:       keyMap,
 		selection:    selection,
 		files:        fileList,
-		config:       cfg.UI,
+		config:       uiCfg,
 		list:         l,
 		viewport:     viewport.Model{},
-		styles:       styles.New(cfg.UI),
+		styles:       styles.New(uiCfg),
 		help:         newHelpModel(),
 	}
 }

--- a/internal/ui/ui.go
+++ b/internal/ui/ui.go
@@ -46,6 +46,13 @@ var (
 	ErrInputCanceled = errors.New("input is canceled")
 )
 
+// RenderOptions holds the configuration needed by the UI layer.
+// This avoids passing the full config.Config to the UI package.
+type RenderOptions struct {
+	Config        config.UI
+	DeleteEnabled bool
+}
+
 // Init implements tea.Model
 func (m Model) Init() tea.Cmd {
 	return tea.Batch(
@@ -56,9 +63,9 @@ func (m Model) Init() tea.Cmd {
 }
 
 // Render displays the file selection interface and returns the selected files
-func Render(manager trash.Trash, files []*trash.File, cfg *config.Config) ([]*trash.File, error) {
+func Render(manager trash.Trash, files []*trash.File, opts RenderOptions) ([]*trash.File, error) {
 	// Create and initialize the model
-	m := NewModel(manager, files, cfg)
+	m := NewModel(manager, files, opts)
 
 	// Initialize UI program
 	p := tea.NewProgram(m)
@@ -75,7 +82,7 @@ func Render(manager trash.Trash, files []*trash.File, cfg *config.Config) ([]*tr
 		return nil, fmt.Errorf("unexpected model type: %T", result)
 	}
 	if finalModel.state.current == Quitting {
-		if msg := cfg.UI.ExitMessage; msg != "" {
+		if msg := opts.Config.ExitMessage; msg != "" {
 			fmt.Println(msg)
 		}
 		return nil, nil


### PR DESCRIPTION
## WHAT

Remove unused `trash.Config` fields and replace the full `*config.Config` parameter in the UI layer with a minimal `RenderOptions` struct containing only the fields the UI actually uses.

This PR includes all Phase 1-3 refactoring commits (concurrency safety, structural improvements, and config decoupling).

## WHY

A code review identified that `trash.Config` had 3 fields defined but never referenced (`SkipMountPointFind`, `PreservePaths`, `UseCompression`), and the UI layer received the entire application config when it only needed `config.UI` and a single bool (`DeleteEnabled`). Passing the full config creates unnecessary coupling between the UI and unrelated config sections (trash strategy, logging, history), making it harder to reason about what the UI actually depends on.