### PR TITLE
Update architecture docs and rename manager variables to match Trash interface

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -70,6 +70,14 @@ flowchart TD
 
 ```mermaid
 classDiagram
+    class Trash {
+        <<interface>>
+        +Put(src string) error
+        +List() []*File
+        +Restore(file *File, dst string) error
+        +Remove(file *File) error
+    }
+
     class Manager {
         -storages []Storage
         -config Config
@@ -78,6 +86,7 @@ classDiagram
         +Put(src string) error
         +List() []*File
         +Restore(file *File, dst string) error
+        +Remove(file *File) error
         +IsPrimaryStorageAvailable() bool
     }
 
@@ -102,6 +111,7 @@ classDiagram
         +Strategy Strategy
         +HomeTrashDir string
         +HomeFallback bool
+        +ForceHomeTrash bool
         +History History
         +GomiDir string
     }
@@ -114,6 +124,7 @@ classDiagram
     }
 
     class LegacyStorage {
+        -mu sync.Mutex
         -root string
         -config Config
         -history History
@@ -135,6 +146,7 @@ classDiagram
         +Type StorageType
     }
 
+    Trash <|.. Manager : implements
     Manager --> Storage : uses
     Manager --> Strategy : determines
     Manager --> Config : configured by
@@ -148,9 +160,13 @@ classDiagram
 
 </details>
 
+### Trash Interface
+
+The `Trash` interface defines the public API for trash operations (`Put`, `List`, `Restore`, `Remove`). The CLI and UI layers depend on this interface rather than the concrete `Manager` type, enabling mock-based testing and loose coupling.
+
 ### Storage Manager
 
-The Storage Manager acts as a coordinator for multiple storage implementations:
+The `Manager` implements the `Trash` interface and acts as a coordinator for multiple storage implementations:
 
 - Manages multiple storage backends
 - Routes operations based on selected strategy

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -62,7 +62,7 @@ type CLI struct {
 	option  Option
 	config  *config.Config
 	runID   string
-	manager trash.Trash
+	trash   trash.Trash
 }
 
 var runID = sync.OnceValue(func() string {
@@ -93,7 +93,7 @@ func Run(v Version) error {
 		return err
 	}
 
-	manager, err := newTrashManager(cfg)
+	t, err := newTrashManager(cfg)
 	if err != nil {
 		return err
 	}
@@ -110,7 +110,7 @@ func Run(v Version) error {
 		option:  *opt,
 		config:  cfg,
 		runID:   runID(),
-		manager: manager,
+		trash:   t,
 	}
 
 	if err := cli.Run(args); err != nil {

--- a/internal/cli/prune.go
+++ b/internal/cli/prune.go
@@ -85,7 +85,7 @@ func (c *CLI) permanentlyDeleteByTimeRange(durations []time.Duration) error {
 	}
 
 	slog.Debug("Get all files from trash")
-	files, err := c.manager.List()
+	files, err := c.trash.List()
 	if err != nil {
 		return fmt.Errorf("failed to list trash contents: %w", err)
 	}
@@ -138,7 +138,7 @@ func (c *CLI) permanentlyDeleteByTimeRange(durations []time.Duration) error {
 	var failedDeletions []string
 	for _, file := range filesToDelete {
 		slog.Debug("removing trash file", "file", file.OriginalPath)
-		if err := c.manager.Remove(file); err != nil {
+		if err := c.trash.Remove(file); err != nil {
 			slog.Error("failed to remove file", "file", file.Name, "error", err)
 			failedDeletions = append(failedDeletions, file.Name)
 		}

--- a/internal/cli/put.go
+++ b/internal/cli/put.go
@@ -93,7 +93,7 @@ func (c *CLI) processFile(arg string, failed *syncStringSlice) error {
 	}
 
 	// Move to trash
-	err = c.manager.Put(path)
+	err = c.trash.Put(path)
 	if err != nil {
 		if !c.option.Rm.Force {
 			failed.Append(arg)

--- a/internal/cli/restore.go
+++ b/internal/cli/restore.go
@@ -17,7 +17,7 @@ func (c *CLI) Restore() error {
 	defer slog.Debug("cli.restore finished")
 
 	// Get list of files in trash
-	files, err := c.manager.List()
+	files, err := c.trash.List()
 	if err != nil {
 		return fmt.Errorf("failed to list trash contents: %w", err)
 	}
@@ -35,7 +35,7 @@ func (c *CLI) Restore() error {
 	}
 
 	// Show UI for file selection
-	selected, err := ui.Render(c.manager, filtered, ui.RenderOptions{
+	selected, err := ui.Render(c.trash, filtered, ui.RenderOptions{
 		Config:        c.config.UI,
 		DeleteEnabled: c.config.Core.PermanentDelete.Enable,
 	})
@@ -112,7 +112,7 @@ func (c *CLI) restoreFile(file *trash.File) error {
 	}
 
 	// Perform the restore
-	if err := c.manager.Restore(file, originalPath); err != nil {
+	if err := c.trash.Restore(file, originalPath); err != nil {
 		return fmt.Errorf("failed to restore '%s': %w", file.Name, err)
 	}
 

--- a/internal/ui/commands.go
+++ b/internal/ui/commands.go
@@ -46,7 +46,7 @@ func deletePermanentlyCmd(m *Model, files ...File) tea.Cmd {
 	return func() tea.Msg {
 		for _, file := range files {
 			slog.Debug("permanently delete", "file", file.TrashPath)
-			if err := m.trashManager.Remove(file.File); err != nil {
+			if err := m.trash.Remove(file.File); err != nil {
 				return FileListUpdatedMsg{err: err}
 			}
 		}

--- a/internal/ui/model.go
+++ b/internal/ui/model.go
@@ -15,8 +15,8 @@ import (
 
 // Model represents the main UI model following the Bubble Tea pattern
 type Model struct {
-	// Manager handles trash operations
-	trashManager trash.Trash
+	// Trash handles trash operations (put, list, restore, remove)
+	trash trash.Trash
 
 	// State management
 	state *ViewState
@@ -46,7 +46,7 @@ type Model struct {
 }
 
 // NewModel creates a new UI model instance
-func NewModel(manager trash.Trash, files []*trash.File, opts RenderOptions) Model {
+func NewModel(t trash.Trash, files []*trash.File, opts RenderOptions) Model {
 	var items []list.Item
 	var fileList []File
 
@@ -98,15 +98,15 @@ func NewModel(manager trash.Trash, files []*trash.File, opts RenderOptions) Mode
 
 	// Return fully initialized model
 	return Model{
-		trashManager: manager,
-		state:        NewViewState(),
-		keyMap:       keyMap,
-		selection:    selection,
-		files:        fileList,
-		config:       uiCfg,
-		list:         l,
-		viewport:     viewport.Model{},
-		styles:       styles.New(uiCfg),
-		help:         newHelpModel(),
+		trash:     t,
+		state:     NewViewState(),
+		keyMap:    keyMap,
+		selection: selection,
+		files:     fileList,
+		config:    uiCfg,
+		list:      l,
+		viewport:  viewport.Model{},
+		styles:    styles.New(uiCfg),
+		help:      newHelpModel(),
 	}
 }

--- a/internal/ui/ui.go
+++ b/internal/ui/ui.go
@@ -63,9 +63,9 @@ func (m Model) Init() tea.Cmd {
 }
 
 // Render displays the file selection interface and returns the selected files
-func Render(manager trash.Trash, files []*trash.File, opts RenderOptions) ([]*trash.File, error) {
+func Render(t trash.Trash, files []*trash.File, opts RenderOptions) ([]*trash.File, error) {
 	// Create and initialize the model
-	m := NewModel(manager, files, opts)
+	m := NewModel(t, files, opts)
 
 	// Initialize UI program
 	p := tea.NewProgram(m)


### PR DESCRIPTION
## WHAT

Update `docs/architecture.md` to reflect the Phase 1-3 refactoring changes, and rename `manager` variables across CLI and UI to `trash` to match the `trash.Trash` interface they now hold.

## WHY

After introducing the `Trash` interface, variables like `cli.CLI.manager` and `ui.Model.trashManager` still carried the old `Manager` name despite holding an interface value. Variable names should reflect their type. The architecture documentation also lacked the new `Trash` interface in its class diagram.