### PR TITLE
Fix fundamental design issues: circular references, untestable prompts, and implicit init()

### DIFF
--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -82,6 +82,8 @@ var runID = sync.OnceValue(func() string {
 
 // Run is the main entry point for the CLI
 func Run(v Version) error {
+	env.Init()
+
 	opt, args, err := parseOptions(v)
 	if err != nil {
 		return err

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -19,6 +19,7 @@ import (
 	"github.com/babarot/gomi/internal/trash"
 	"github.com/babarot/gomi/internal/trash/legacy"
 	"github.com/babarot/gomi/internal/trash/xdg"
+	"github.com/babarot/gomi/internal/ui"
 	"github.com/babarot/gomi/internal/utils/debug"
 	"github.com/babarot/gomi/internal/utils/env"
 	"github.com/babarot/gomi/internal/utils/log"
@@ -57,12 +58,21 @@ type RmOption struct {
 	Verbose     bool `short:"v" long:"verbose" description:"(dummy) explain what is being done"`
 }
 
+// Prompter abstracts user interaction for confirmation and input.
+// This enables mock-based testing of CLI commands that require user prompts.
+type Prompter interface {
+	Confirm(prompt string) bool
+	ConfirmYes(prompt string) bool
+	InputFilename(file *trash.File) (string, error)
+}
+
 type CLI struct {
-	version Version
-	option  Option
-	config  *config.Config
-	runID   string
-	trash   trash.Trash
+	version  Version
+	option   Option
+	config   *config.Config
+	runID    string
+	trash    trash.Trash
+	prompter Prompter
 }
 
 var runID = sync.OnceValue(func() string {
@@ -106,11 +116,12 @@ func Run(v Version) error {
 	defer slog.Debug("main function finished")
 
 	cli := CLI{
-		version: v,
-		option:  *opt,
-		config:  cfg,
-		runID:   runID(),
-		trash:   t,
+		version:  v,
+		option:   *opt,
+		config:   cfg,
+		runID:    runID(),
+		trash:    t,
+		prompter: &uiPrompter{},
 	}
 
 	if err := cli.Run(args); err != nil {
@@ -281,3 +292,10 @@ func newTrashManager(cfg *config.Config) (*trash.Manager, error) {
 
 	return manager, nil
 }
+
+// uiPrompter is the default Prompter implementation that delegates to the ui package.
+type uiPrompter struct{}
+
+func (p *uiPrompter) Confirm(prompt string) bool                  { return ui.Confirm(prompt) }
+func (p *uiPrompter) ConfirmYes(prompt string) bool               { return ui.ConfirmYes(prompt) }
+func (p *uiPrompter) InputFilename(f *trash.File) (string, error) { return ui.InputFilename(f) }

--- a/internal/cli/prune.go
+++ b/internal/cli/prune.go
@@ -11,7 +11,6 @@ import (
 
 	"github.com/babarot/gomi/internal/trash"
 	"github.com/babarot/gomi/internal/trash/xdg"
-	"github.com/babarot/gomi/internal/ui"
 	"github.com/babarot/gomi/internal/ui/table"
 	"github.com/babarot/gomi/internal/utils/duration"
 )
@@ -120,7 +119,7 @@ func (c *CLI) permanentlyDeleteByTimeRange(durations []time.Duration) error {
 	printDeletionSummary(filesToDelete, newestAge, oldestAge, len(durations) == 1)
 
 	// First confirmation
-	if !ui.Confirm(fmt.Sprintf("Are you sure you want to remove these %d files?", len(filesToDelete))) {
+	if !c.prompter.Confirm(fmt.Sprintf("Are you sure you want to remove these %d files?", len(filesToDelete))) {
 		fmt.Println("Operation canceled.")
 		return nil
 	}
@@ -129,7 +128,7 @@ func (c *CLI) permanentlyDeleteByTimeRange(durations []time.Duration) error {
 	fmt.Println()
 	// WARNING: Files will be permanently deleted and CANNOT be recovered. Are you absolutely sure?
 	fmt.Printf("%s\n", color.New(color.FgHiRed).Sprint("WARNING: This operation is permanent and cannot be undone!"))
-	if !ui.ConfirmYes("Do you really want to permanently delete these files?") {
+	if !c.prompter.ConfirmYes("Do you really want to permanently delete these files?") {
 		fmt.Println("Operation canceled.")
 		return nil
 	}
@@ -207,7 +206,7 @@ func (c *CLI) removeOrphanedMetadata() error {
 			Order:            table.SortDesc,
 		})
 		fmt.Println()
-		if !ui.Confirm(fmt.Sprintf("Are you sure you want to remove %d orphaned metadata files?", len(orphanedFiles))) {
+		if !c.prompter.Confirm(fmt.Sprintf("Are you sure you want to remove %d orphaned metadata files?", len(orphanedFiles))) {
 			fmt.Println("Operation canceled.")
 			return nil
 		}

--- a/internal/cli/restore.go
+++ b/internal/cli/restore.go
@@ -84,7 +84,7 @@ func (c *CLI) restoreFile(file *trash.File) error {
 	// Check if the file exists at the original location
 	if _, err := os.Stat(originalPath); err == nil {
 		// File exists at original location, ask for new name if necessary
-		newName, err := ui.InputFilename(file)
+		newName, err := c.prompter.InputFilename(file)
 		if err != nil {
 			if errors.Is(err, ui.ErrInputCanceled) {
 				c.printVerbose("Canceled! No new filename input.\n")
@@ -97,7 +97,7 @@ func (c *CLI) restoreFile(file *trash.File) error {
 	}
 
 	// If configured, ask for confirmation
-	if c.config.Core.Restore.Confirm && !ui.Confirm(fmt.Sprintf("OK to restore? %s", filepath.Base(originalPath))) {
+	if c.config.Core.Restore.Confirm && !c.prompter.Confirm(fmt.Sprintf("OK to restore? %s", filepath.Base(originalPath))) {
 		c.printVerbose("Replied no, canceled!\n")
 		return nil
 	}
@@ -105,7 +105,7 @@ func (c *CLI) restoreFile(file *trash.File) error {
 	// Check again if destination exists (might have been created while confirming)
 	if _, err := os.Stat(originalPath); err == nil {
 		msg := fmt.Sprintf("Caution! The same name already exists. Even so okay to restore? %s", filepath.Base(originalPath))
-		if !ui.Confirm(msg) {
+		if !c.prompter.Confirm(msg) {
 			c.printVerbose("Replied no, canceled!\n")
 			return nil
 		}

--- a/internal/trash/legacy/history/history.go
+++ b/internal/trash/legacy/history/history.go
@@ -55,6 +55,7 @@ func New(home string, c config.History) History {
 	if home == "" {
 		home = filepath.Join(os.Getenv("HOME"), ".gomi")
 	}
+	migrateIfNeeded(home)
 	return History{
 		home:   home,
 		path:   filepath.Join(home, Filename),

--- a/internal/trash/legacy/history/migration.go
+++ b/internal/trash/legacy/history/migration.go
@@ -1,27 +1,22 @@
 package history
 
 import (
-	"log"
+	"log/slog"
 	"os"
 	"path/filepath"
 )
 
 const OldFilename = "inventory.json"
 
-// init is called when the application starts, to handle migration from inventory.json to history.json
-func init() {
-	// Before v1.2.2, the trash home was fixed, so these are hardcoded in the migration script.
-	fixedHome := filepath.Join(os.Getenv("HOME"), ".gomi")
+// migrateIfNeeded renames inventory.json to history.json if it exists.
+// Before v1.2.2, the history file was called inventory.json.
+func migrateIfNeeded(home string) {
+	oldPath := filepath.Join(home, OldFilename)
+	newPath := filepath.Join(home, Filename)
 
-	oldPath := filepath.Join(fixedHome, OldFilename)
-	newPath := filepath.Join(fixedHome, Filename)
-
-	// Check if inventory.json exists and rename it to history.json
 	if _, err := os.Stat(oldPath); err == nil {
-		// File exists, so rename it
-		err := os.Rename(oldPath, newPath)
-		if err != nil {
-			log.Fatalf("Failed to rename file %s to %s: %v", oldPath, newPath, err)
+		if err := os.Rename(oldPath, newPath); err != nil {
+			slog.Error("failed to migrate history file", "from", oldPath, "to", newPath, "error", err)
 		}
 	}
 }

--- a/internal/trash/legacy/storage.go
+++ b/internal/trash/legacy/storage.go
@@ -156,7 +156,6 @@ func (s *Storage) List() ([]*trash.File, error) {
 			file.FileMode = info.Mode()
 		}
 
-		file.SetStorage(s)
 		files = append(files, file)
 	}
 

--- a/internal/trash/manager.go
+++ b/internal/trash/manager.go
@@ -177,36 +177,9 @@ func (m *Manager) List() ([]*File, error) {
 
 // Restore restores the given file
 func (m *Manager) Restore(file *File, dst string) error {
-	// Find the appropriate storage for this file
-	var targetStorage Storage
-	for _, storage := range m.storages {
-		slog.Debug("checking storage",
-			"file", strings.Join([]string{
-				"name: " + file.Name,
-				"trashPath: " + file.TrashPath,
-				"originalPath: " + file.OriginalPath,
-			}, "\n"),
-			"info", strings.Join([]string{
-				fmt.Sprintf("type: %s", storage.Info().Type),
-				"trashes: " + strings.Join(storage.Info().Trashes, ", "),
-			}, "\n"),
-		)
-		foundStorage := func() bool {
-			for _, trashRoot := range storage.Info().Trashes {
-				if strings.HasPrefix(file.TrashPath, trashRoot) {
-					return true
-				}
-			}
-			return false
-		}()
-		if foundStorage {
-			targetStorage = storage
-			break
-		}
-	}
-
-	if targetStorage == nil {
-		return errors.New("file does not belong to any known storage")
+	storage, err := m.findStorageForFile(file)
+	if err != nil {
+		return err
 	}
 
 	if dst == "" {
@@ -218,33 +191,30 @@ func (m *Manager) Restore(file *File, dst string) error {
 		return ErrFileExists
 	}
 
-	return targetStorage.Restore(file, dst)
+	return storage.Restore(file, dst)
 }
 
 // Remove permanently removes the file from trash
 func (m *Manager) Remove(file *File) error {
-	// Find the appropriate storage for this file
-	var targetStorage Storage
+	storage, err := m.findStorageForFile(file)
+	if err != nil {
+		return err
+	}
+
+	return storage.Remove(file)
+}
+
+// findStorageForFile returns the storage backend that manages the given file,
+// determined by matching the file's trash path against each storage's root paths.
+func (m *Manager) findStorageForFile(file *File) (Storage, error) {
 	for _, storage := range m.storages {
-		foundStorage := func() bool {
-			for _, trashRoot := range storage.Info().Trashes {
-				if strings.HasPrefix(file.TrashPath, trashRoot) {
-					return true
-				}
+		for _, trashRoot := range storage.Info().Trashes {
+			if strings.HasPrefix(file.TrashPath, trashRoot) {
+				return storage, nil
 			}
-			return false
-		}()
-		if foundStorage {
-			targetStorage = storage
-			break
 		}
 	}
-
-	if targetStorage == nil {
-		return errors.New("file does not belong to any known storage")
-	}
-
-	return targetStorage.Remove(file)
+	return nil, errors.New("file does not belong to any known storage")
 }
 
 // ListStorages returns information about all available storage backends

--- a/internal/trash/storage.go
+++ b/internal/trash/storage.go
@@ -84,9 +84,6 @@ type File struct {
 	// MountRoot is the root path of the mount point containing this trash
 	// This is used to resolve relative paths in .trashinfo files
 	MountRoot string
-
-	// storage is a reference to the Storage implementation that manages this file
-	storage Storage
 }
 
 func (f *File) GetName() string {
@@ -116,16 +113,6 @@ func (f *File) RequiresAdmin() bool {
 		return false
 	}
 	return info.Mode().Perm()&0200 == 0
-}
-
-// SetStorage sets the storage reference for this file
-func (f *File) SetStorage(s Storage) {
-	f.storage = s
-}
-
-// GetStorage returns the storage reference for this file
-func (f *File) GetStorage() Storage {
-	return f.storage
 }
 
 // GetOriginalPath returns the absolute original path of the file

--- a/internal/trash/storage_test.go
+++ b/internal/trash/storage_test.go
@@ -154,17 +154,3 @@ func TestFile_GetRelativePath(t *testing.T) {
 		})
 	}
 }
-
-func TestFile_Storage(t *testing.T) {
-	f := &File{}
-	if got := f.GetStorage(); got != nil {
-		t.Errorf("expected nil storage, got %v", got)
-	}
-
-	// We can't easily create a mock Storage here since it's in the same package,
-	// but we can verify SetStorage/GetStorage round-trips with nil
-	f.SetStorage(nil)
-	if got := f.GetStorage(); got != nil {
-		t.Errorf("expected nil after SetStorage(nil), got %v", got)
-	}
-}

--- a/internal/trash/xdg/storage.go
+++ b/internal/trash/xdg/storage.go
@@ -329,7 +329,6 @@ func (s *Storage) listLocation(loc *trashLocation) ([]*trash.File, error) {
 			IsDir:        fileInfo.IsDir(),
 			FileMode:     fileInfo.Mode(),
 		}
-		file.SetStorage(s)
 		files = append(files, file)
 	}
 

--- a/internal/utils/env/env.go
+++ b/internal/utils/env/env.go
@@ -3,50 +3,39 @@ package env
 import (
 	"os"
 	"path/filepath"
+	"sync"
 )
 
-const (
-	defaultXDGConfigDirname = ".config"
-	defaultXDGDataDirname   = ".local/share"
-)
+const defaultXDGDataDirname = ".local/share"
 
 var (
-	// TODO: compatible with flag
-	GOMI_CONFIG_PATH string
-
+	// GOMI_LOG_PATH is the path to the log file, following XDG base directory spec.
 	GOMI_LOG_PATH string
+
+	once sync.Once
 )
 
-func init() {
-	// https://github.com/charmbracelet/log/issues/35
-	os.Setenv("CLICOLOR_FORCE", "1")
+// Init initializes environment paths. It is safe to call multiple times;
+// only the first call has effect. This replaces the previous init() function
+// to avoid implicit side effects on package import.
+func Init() {
+	once.Do(func() {
+		// https://github.com/charmbracelet/log/issues/35
+		os.Setenv("CLICOLOR_FORCE", "1")
 
-	// Follow https://specifications.freedesktop.org/basedir-spec/latest/
-	if e := os.Getenv("GOMI_CONFIG_PATH"); e == "" {
-		configDir := os.Getenv("XDG_CONFIG_HOME")
-		if configDir == "" {
-			homeDir, err := os.UserHomeDir()
-			if err != nil {
-				panic(err)
+		// Follow https://specifications.freedesktop.org/basedir-spec/latest/
+		if e := os.Getenv("GOMI_LOG_PATH"); e == "" {
+			dataDir := os.Getenv("XDG_DATA_HOME")
+			if dataDir == "" {
+				homeDir, err := os.UserHomeDir()
+				if err != nil {
+					panic(err)
+				}
+				dataDir = filepath.Join(homeDir, defaultXDGDataDirname)
 			}
-			configDir = filepath.Join(homeDir, defaultXDGConfigDirname)
+			GOMI_LOG_PATH = filepath.Join(dataDir, "gomi", "debug.log")
+		} else {
+			GOMI_LOG_PATH = e
 		}
-		GOMI_CONFIG_PATH = filepath.Join(configDir, "gomi", "config.yaml")
-	} else {
-		GOMI_CONFIG_PATH = os.Getenv("GOMI_CONFIG_PATH")
-	}
-
-	if e := os.Getenv("GOMI_LOG_PATH"); e == "" {
-		dataDir := os.Getenv("XDG_DATA_HOME")
-		if dataDir == "" {
-			homeDir, err := os.UserHomeDir()
-			if err != nil {
-				panic(err)
-			}
-			dataDir = filepath.Join(homeDir, defaultXDGDataDirname)
-		}
-		GOMI_LOG_PATH = filepath.Join(dataDir, "gomi", "debug.log")
-	} else {
-		GOMI_LOG_PATH = os.Getenv("GOMI_LOG_PATH")
-	}
+	})
 }


### PR DESCRIPTION
## WHAT

Address four fundamental design problems identified during code review: remove the circular File-Storage reference, extract a Prompter interface for testable CLI interactions, deduplicate Manager's storage lookup, and replace two `init()` functions with explicit initialization.

## WHY

1. **File.storage circular reference** — File held a reference back to its managing Storage, but Manager never used it (it finds storage via TrashPath prefix matching). The field existed only as dead weight creating a circular dependency.

2. **Untestable CLI prompts** — `restore.go` and `prune.go` called `ui.Confirm()` / `ui.ConfirmYes()` / `ui.InputFilename()` directly, making it impossible to test CLI commands without starting a real BubbleTea terminal program.

3. **Duplicated storage lookup** — `Restore()` and `Remove()` had identical inline closures to find which storage manages a file. `Restore` had verbose debug logging while `Remove` had none.

4. **init() side effects** — Two packages used `init()` to perform filesystem operations on import: `env` set global path variables, and `history/migration` renamed files. Both violated the principle of explicit initialization.