### PR TITLE
Reduce syscalls in gomi -b restore path

### DIFF
--- a/internal/trash/filter.go
+++ b/internal/trash/filter.go
@@ -23,6 +23,8 @@ type Filterable interface {
 	GetPath() string
 	// GetDeletedAt returns when the file was trashed
 	GetDeletedAt() time.Time
+	// GetSize returns the cached size in bytes, or 0 if unknown
+	GetSize() int64
 }
 
 // FilterOptions holds filtering configuration
@@ -60,7 +62,7 @@ func Filter[T Filterable](items []T, opts FilterOptions) []T {
 	slog.Debug("after glob filtering", "len(items)", len(items))
 
 	// Filter by size
-	items = rejectBySize(items, opts.Exclude.Size, nil)
+	items = rejectBySize(items, opts.Exclude.Size)
 	slog.Debug("after size filtering", "len(items)", len(items))
 
 	// Filter by time period
@@ -127,32 +129,34 @@ func rejectByGlobs[T Filterable](items []T, globs []string) []T {
 	return filtered
 }
 
-func rejectBySize[T Filterable](
-	items []T,
-	size config.SizeConfig,
-	dirSizeFunc func(string) (int64, error),
-) []T {
-	if dirSizeFunc == nil {
-		dirSizeFunc = fs.DirSize
+func rejectBySize[T Filterable](items []T, size config.SizeConfig) []T {
+	if size.Min == "" && size.Max == "" {
+		return items
 	}
+
 	var filtered []T
 	for _, item := range items {
-		dirSize, err := dirSizeFunc(item.GetPath())
-		if err != nil {
-			continue // Skip items we can't size
+		// Use cached size from List(); fall back to DirSize for unknown sizes
+		fileSize := item.GetSize()
+		if fileSize == 0 {
+			var err error
+			fileSize, err = fs.DirSize(item.GetPath())
+			if err != nil {
+				continue // Skip items we can't size
+			}
 		}
 
 		include := true
 		if size.Min != "" {
 			if min, err := units.FromHumanSize(size.Min); err == nil {
-				if dirSize < min {
+				if fileSize < min {
 					include = false
 				}
 			}
 		}
 		if size.Max != "" {
 			if max, err := units.FromHumanSize(size.Max); err == nil {
-				if max < dirSize {
+				if max < fileSize {
 					include = false
 				}
 			}

--- a/internal/trash/filter_test.go
+++ b/internal/trash/filter_test.go
@@ -1,7 +1,6 @@
 package trash
 
 import (
-	"fmt"
 	"slices"
 	"testing"
 	"time"
@@ -13,52 +12,28 @@ import (
 type TestItem struct {
 	name      string
 	path      string
+	size      int64
 	deletedAt time.Time
 }
 
-func (t TestItem) GetName() string {
-	return t.name
-}
-
-func (t TestItem) GetPath() string {
-	return t.path
-}
-
-func (t TestItem) GetDeletedAt() time.Time {
-	return t.deletedAt
-}
+func (t TestItem) GetName() string         { return t.name }
+func (t TestItem) GetPath() string         { return t.path }
+func (t TestItem) GetDeletedAt() time.Time { return t.deletedAt }
+func (t TestItem) GetSize() int64          { return t.size }
 
 // createTestItems generates a slice of test items for various test scenarios
 func createTestItems() []TestItem {
 	now := time.Now()
 	return []TestItem{
-		{name: "file1.txt", path: "/trash/file1.txt", deletedAt: now.Add(-24 * time.Hour)},
-		{name: "file2.log", path: "/trash/file2.log", deletedAt: now.Add(-48 * time.Hour)},
-		{name: "important.txt", path: "/trash/important.txt", deletedAt: now.Add(-72 * time.Hour)},
-		{name: "temp.tmp", path: "/trash/temp.tmp", deletedAt: now.Add(-96 * time.Hour)},
-	}
-}
-
-// createMockDirSizeFunc creates a mock DirSize function for testing
-func createMockDirSizeFunc() func(string) (int64, error) {
-	return func(path string) (int64, error) {
-		sizemap := map[string]int64{
-			"/trash/file1.txt":     100,    // 100 bytes
-			"/trash/file2.log":     1024,   // 1 KB
-			"/trash/important.txt": 10240,  // 10 KB
-			"/trash/temp.tmp":      102400, // 100 KB
-		}
-		size, exists := sizemap[path]
-		if !exists {
-			return 0, fmt.Errorf("path not found in mock")
-		}
-		return size, nil
+		{name: "file1.txt", path: "/trash/file1.txt", size: 100, deletedAt: now.Add(-24 * time.Hour)},
+		{name: "file2.log", path: "/trash/file2.log", size: 1024, deletedAt: now.Add(-48 * time.Hour)},
+		{name: "important.txt", path: "/trash/important.txt", size: 10240, deletedAt: now.Add(-72 * time.Hour)},
+		{name: "temp.tmp", path: "/trash/temp.tmp", size: 102400, deletedAt: now.Add(-96 * time.Hour)},
 	}
 }
 
 func TestRejectBySize(t *testing.T) {
 	items := createTestItems()
-	mockDirSizeFunc := createMockDirSizeFunc()
 
 	testCases := []struct {
 		name          string
@@ -101,7 +76,7 @@ func TestRejectBySize(t *testing.T) {
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			// Use the mock DirSize function in the filter
-			filtered := rejectBySize(items, tc.sizeConfig, mockDirSizeFunc)
+			filtered := rejectBySize(items, tc.sizeConfig)
 
 			if len(filtered) != tc.expectedCount {
 				t.Errorf("Expected %d items, got %d", tc.expectedCount, len(filtered))
@@ -119,14 +94,12 @@ func TestRejectBySize(t *testing.T) {
 }
 
 func TestFilter(t *testing.T) {
-	mockDirSizeFunc := createMockDirSizeFunc()
-
 	now := time.Now()
 	items := []TestItem{
-		{name: "file1.txt", path: "/trash/file1.txt", deletedAt: now.Add(-24 * time.Hour)},
-		{name: "file2.log", path: "/trash/file2.log", deletedAt: now.Add(-48 * time.Hour)},
-		{name: "important.txt", path: "/trash/important.txt", deletedAt: now.Add(-72 * time.Hour)},
-		{name: "temp.tmp", path: "/trash/temp.tmp", deletedAt: now.Add(-96 * time.Hour)},
+		{name: "file1.txt", path: "/trash/file1.txt", size: 100, deletedAt: now.Add(-24 * time.Hour)},
+		{name: "file2.log", path: "/trash/file2.log", size: 1024, deletedAt: now.Add(-48 * time.Hour)},
+		{name: "important.txt", path: "/trash/important.txt", size: 10240, deletedAt: now.Add(-72 * time.Hour)},
+		{name: "temp.tmp", path: "/trash/temp.tmp", size: 102400, deletedAt: now.Add(-96 * time.Hour)},
 	}
 
 	testCases := []struct {
@@ -161,8 +134,7 @@ func TestFilter(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			// Use the mock DirSize function in the filter
-			filtered := rejectBySize(items, tc.filterOptions.Exclude.Size, mockDirSizeFunc)
+			filtered := rejectBySize(items, tc.filterOptions.Exclude.Size)
 
 			if len(filtered) != tc.expectedCount {
 				t.Errorf("Expected %d items, got %d", tc.expectedCount, len(filtered))

--- a/internal/trash/legacy/history/history.go
+++ b/internal/trash/legacy/history/history.go
@@ -51,6 +51,10 @@ func (f File) GetDeletedAt() time.Time {
 	return f.Timestamp
 }
 
+func (f File) GetSize() int64 {
+	return 0 // Size is not stored in legacy history; will fall back to DirSize
+}
+
 func New(home string, c config.History) History {
 	if home == "" {
 		home = filepath.Join(os.Getenv("HOME"), ".gomi")

--- a/internal/trash/manager.go
+++ b/internal/trash/manager.go
@@ -147,25 +147,38 @@ func (m *Manager) Put(src string) error {
 
 // List returns all files from all storage backends
 func (m *Manager) List() ([]*File, error) {
-	var allFiles []*File
-	var errs []error
-
 	slog.Debug("storage manager list")
 
+	type result struct {
+		files []*File
+		err   error
+	}
+
+	ch := make(chan result, len(m.storages))
 	for _, storage := range m.storages {
-		files, err := storage.List()
-		if err != nil {
-			errs = append(errs, fmt.Errorf("failed to list files from %s: %w",
-				storage.Info().Trashes, err))
+		go func(s Storage) {
+			files, err := s.List()
+			if err != nil {
+				ch <- result{err: fmt.Errorf("failed to list files from %s: %w",
+					s.Info().Trashes, err)}
+				return
+			}
+			slog.Info("list files",
+				"storage_type", s.Info().Type,
+				"len(files)", len(files))
+			ch <- result{files: files}
+		}(storage)
+	}
+
+	var allFiles []*File
+	var errs []error
+	for range m.storages {
+		r := <-ch
+		if r.err != nil {
+			errs = append(errs, r.err)
 			continue
 		}
-		allFiles = append(allFiles, files...)
-		slog.Info("list files",
-			"storage_type",
-			storage.Info().Type,
-			"len(files)",
-			len(files),
-		)
+		allFiles = append(allFiles, r.files...)
 	}
 
 	if len(allFiles) == 0 && len(errs) > 0 {

--- a/internal/trash/storage.go
+++ b/internal/trash/storage.go
@@ -98,6 +98,10 @@ func (f *File) GetDeletedAt() time.Time {
 	return f.DeletedAt
 }
 
+func (f *File) GetSize() int64 {
+	return f.Size
+}
+
 // Exists checks if the file still exists in the trash
 func (f *File) Exists() bool {
 	_, err := os.Stat(f.TrashPath)

--- a/internal/ui/commands.go
+++ b/internal/ui/commands.go
@@ -25,13 +25,7 @@ func loadFileListCmd(files []File) tea.Cmd {
 			return files[i].DeletedAt.After(files[j].DeletedAt)
 		})
 
-		// Filter out files that no longer exist
-		files = lo.Reject(files, func(f File, index int) bool {
-			_, err := os.Stat(f.TrashPath)
-			return os.IsNotExist(err)
-		})
-
-		// Convert to list items
+		// Convert to list items (existence already checked by cli.filterFiles)
 		items := make([]list.Item, len(files))
 		for i, file := range files {
 			items[i] = file

--- a/internal/ui/file.go
+++ b/internal/ui/file.go
@@ -38,11 +38,6 @@ type File struct {
 }
 
 func (f File) Description() string {
-	_, err := os.Stat(f.TrashPath)
-	if os.IsNotExist(err) {
-		return "(already might have been deleted or unmounted)"
-	}
-
 	return fmt.Sprintf("%s %s %s",
 		humanize.Time(f.DeletedAt),
 		bullet,
@@ -51,11 +46,7 @@ func (f File) Description() string {
 }
 
 func (f File) Title() string {
-	fi, err := os.Stat(f.TrashPath)
-	if err != nil {
-		return f.Name + "?"
-	}
-	if fi.IsDir() {
+	if f.IsDir {
 		return f.Name + "/"
 	}
 	return f.Name


### PR DESCRIPTION
## WHAT

Eliminate redundant filesystem syscalls in the `gomi -b` restore flow by using cached file metadata, removing duplicate existence checks, and parallelizing storage listing.

## WHY

Profiling showed `gomi -b` spent 85% of CPU time in syscalls (`system 0.47s` of `0.55s` total CPU). Three sources of waste were identified:

1. **`rejectBySize` called `fs.DirSize()` for every file** — recursively walking directories to compute sizes, even though `File.Size` was already populated during `List()` via `os.Stat()`. The default config sets `Max: "10GB"`, so this ran on every invocation.

2. **`Title()` and `Description()` called `os.Stat()` on every render** — BubbleTea re-renders visible items on each frame, causing V×2 stat calls per frame. `File.IsDir` from the initial List was sufficient.

3. **`loadFileListCmd` re-checked file existence** — `os.Stat()` on every file, duplicating the check already done by `cli.filterFiles()`.

4. **Storage backends listed sequentially** — XDG and Legacy `List()` calls ran one after another instead of concurrently.

This PR also includes prior refactoring commits (design improvements from Phases 1-3).