### PR TITLE
fix: keep restore TUI within terminal bounds (closes #125)

### DIFF
--- a/internal/ui/update.go
+++ b/internal/ui/update.go
@@ -28,7 +28,20 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		}
 
 	case tea.WindowSizeMsg:
-		m.list.SetWidth(msg.Width)
+		// view.go appends a help block wrapped in lipgloss Margin(1, 2)
+		// below the list: 1 row top margin + 1 row content + 1 row bottom
+		// margin = 3 rows tall, and 2 cols on each side = 4 cols total.
+		const (
+			helpReservedRows = 3
+			helpReservedCols = 4
+		)
+		if msg.Width > 0 {
+			m.list.SetWidth(msg.Width)
+			m.help.Width = max(msg.Width-helpReservedCols, 0)
+		}
+		if msg.Height > 0 {
+			m.list.SetHeight(max(msg.Height-helpReservedRows, 1))
+		}
 		return m, tea.Batch(cmds...)
 
 	case FileListUpdatedMsg:

--- a/internal/ui/update_test.go
+++ b/internal/ui/update_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/charmbracelet/bubbles/list"
 	"github.com/charmbracelet/bubbles/viewport"
 	tea "github.com/charmbracelet/bubbletea"
+	"github.com/charmbracelet/lipgloss"
 
 	"github.com/babarot/gomi/internal/config"
 	"github.com/babarot/gomi/internal/trash"
@@ -57,6 +58,88 @@ func TestUpdate_WindowSizeMsg(t *testing.T) {
 
 	if model.list.Width() != 120 {
 		t.Errorf("list width = %d, want 120", model.list.Width())
+	}
+}
+
+func TestUpdate_WindowSizeMsg_ShrinksListHeight(t *testing.T) {
+	m := newTestModel()
+
+	const termHeight = 20
+	msg := tea.WindowSizeMsg{Width: 80, Height: termHeight}
+	updated, _ := m.Update(msg)
+	model := asModel(t, updated)
+
+	if model.list.Height() > termHeight {
+		t.Errorf("list height = %d, want <= %d (terminal height); "+
+			"list is not following the terminal height and will push items off-screen",
+			model.list.Height(), termHeight)
+	}
+}
+
+func TestUpdate_WindowSizeMsg_SetsHelpWidth(t *testing.T) {
+	m := newTestModel()
+
+	const termWidth = 70
+	msg := tea.WindowSizeMsg{Width: termWidth, Height: 20}
+	updated, _ := m.Update(msg)
+	model := asModel(t, updated)
+
+	if model.help.Width == 0 {
+		t.Fatal("help.Width = 0; the help model was not informed of the " +
+			"terminal width, so its View() will not truncate and may overflow")
+	}
+	if model.help.Width > termWidth {
+		t.Errorf("help.Width = %d, want <= %d (terminal width)",
+			model.help.Width, termWidth)
+	}
+}
+
+func TestView_FitsSmallTerminal(t *testing.T) {
+	m := newTestModel()
+	m.help = newHelpModel()
+	m.state.SetView(ListView)
+
+	const (
+		termWidth  = 70
+		termHeight = 20
+	)
+	msg := tea.WindowSizeMsg{Width: termWidth, Height: termHeight}
+	updated, _ := m.Update(msg)
+	model := asModel(t, updated)
+
+	view := model.View()
+
+	if h := lipgloss.Height(view); h > termHeight {
+		t.Errorf("View height = %d lines, want <= %d; "+
+			"output is taller than the terminal so the top rows scroll off",
+			h, termHeight)
+	}
+	if w := lipgloss.Width(view); w > termWidth {
+		t.Errorf("View width = %d cols, want <= %d; "+
+			"output is wider than the terminal so the right edge is clipped/wrapped",
+			w, termWidth)
+	}
+}
+
+// TestUpdate_WindowSizeMsg_HeightZero verifies that a synthetic
+// WindowSizeMsg with only Width set (sent by confirm-view cancel
+// paths in update.go) does not collapse the list height.
+func TestUpdate_WindowSizeMsg_HeightZero(t *testing.T) {
+	m := newTestModel()
+
+	// First, set a real terminal size.
+	updated, _ := m.Update(tea.WindowSizeMsg{Width: 120, Height: 40})
+	m = asModel(t, updated)
+	prevHeight := m.list.Height()
+
+	// Then send a width-only message (Height == 0).
+	updated, _ = m.Update(tea.WindowSizeMsg{Width: m.list.Width()})
+	model := asModel(t, updated)
+
+	if model.list.Height() != prevHeight {
+		t.Errorf("list height = %d, want %d; "+
+			"width-only WindowSizeMsg must not change list height",
+			model.list.Height(), prevHeight)
 	}
 }
 


### PR DESCRIPTION
## WHAT

Adjust the restore TUI to follow the actual terminal size on `WindowSizeMsg`. The list height now shrinks to fit, the help row is told the terminal width so bubbles can truncate it, and width-only resize messages no longer collapse the list.

## WHY

Reported in #125: in small terminals the `gomi --restore` view broke. The list items were pushed off the top because the list kept its default 30-row height, and the short-help row overflowed the terminal width and wrapped mid-word.

The `WindowSizeMsg` handler in `internal/ui/update.go` only called `m.list.SetWidth(msg.Width)`. The height was never updated and `m.help.Width` was left at 0, so the help model could not truncate its output.

A naive fix (always derive list height from `msg.Height`) introduces a regression: the confirm-view cancel paths in `updateConfirmView` send a synthetic `tea.WindowSizeMsg{Width: m.list.Width()}` with `Height == 0`, which would collapse the list to 1 row every time the user dismisses the confirm dialog. The fix therefore guards each dimension independently.

## HOW

`internal/ui/update.go`: in the `tea.WindowSizeMsg` branch, update width and height only when the corresponding field is positive. The list is sized via `SetWidth` / `SetHeight`, reserving 3 rows and 4 columns for the help block that `view.go` renders below the list with `lipgloss.Margin(1, 2)`. The reserved values are declared as named constants with a comment that points back to the layout in `view.go` so the magic numbers are traceable.

`internal/ui/update_test.go`: add regression tests covering the small-terminal scenarios. `TestUpdate_WindowSizeMsg_ShrinksListHeight` and `TestUpdate_WindowSizeMsg_SetsHelpWidth` assert the list and help shrink to fit. `TestView_FitsSmallTerminal` is an end-to-end check that `Model.View()` does not exceed the requested terminal width and height. `TestUpdate_WindowSizeMsg_HeightZero` guards against the confirm-cancel synthetic message: after a real resize, a width-only message must not change the list height.

The patch attached to #125 by @u1f992 was used as the starting point; the height-zero guard and accompanying test were added on top to avoid the confirm-cancel regression.