### PR TITLE
ci: pin GitHub Actions to full-length commit SHAs

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -14,14 +14,14 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Setup Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
           go-version-file: go.mod
           cache: true
       - name: Run golangci-lint
-        uses: golangci/golangci-lint-action@v7
+        uses: golangci/golangci-lint-action@82606bf257cbaff209d206a39f5134f0cfbfd2ee # v9.2.1
         with:
           version: latest
 
@@ -38,9 +38,9 @@ jobs:
       actions: write
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Setup Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
           go-version-file: go.mod
           cache: true
@@ -54,7 +54,7 @@ jobs:
           go test ./... -coverprofile=coverage.out -covermode=count -coverpkg="$COVERPKG"
       - name: Run octocov
         if: runner.os == 'Linux'
-        uses: k1LoW/octocov-action@73d561f65d59e66899ed5c87e4621a913b5d5c20 # v1.5.0
+        uses: k1LoW/octocov-action@b3b6ee60482a667950f87553abf1df63217235d9 # v1.5.1
       - name: Extract coverage
         if: runner.os == 'Linux' && github.ref == 'refs/heads/main'
         run: |
@@ -62,7 +62,7 @@ jobs:
           echo "COVERAGE=$COVERAGE" >> $GITHUB_ENV
       - name: Update coverage badge
         if: runner.os == 'Linux' && github.ref == 'refs/heads/main'
-        uses: Schneegans/dynamic-badges-action@v1.7.0
+        uses: Schneegans/dynamic-badges-action@0e50b8bad39e7e1afd3e4e9c2b7dd145fad07501 # v1.8.0
         with:
           auth: ${{ secrets.GIST_SECRET }}
           gistID: 09e491ead047d9430c6b40cc7d4107c8

--- a/.github/workflows/label-sync.yaml
+++ b/.github/workflows/label-sync.yaml
@@ -15,9 +15,9 @@ jobs:
       issues: write
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Sync labels
-        uses: EndBug/label-sync@v2
+        uses: EndBug/label-sync@52074158190acb45f3077f9099fea818aa43f97a # v2.3.3
         with:
           config-file: .github/label-definitions.yaml
           delete-other-labels: true

--- a/.github/workflows/pages.yaml
+++ b/.github/workflows/pages.yaml
@@ -21,10 +21,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
           python-version: '3.11'
 
@@ -42,7 +42,7 @@ jobs:
           EOF
 
       - name: Upload GitHub Pages artifact
-        uses: actions/upload-pages-artifact@v3
+        uses: actions/upload-pages-artifact@fc324d3547104276b827a68afc52ff2a11cc49c9 # v5.0.0
         with:
           path: ./docs
 
@@ -55,4 +55,4 @@ jobs:
     steps:
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v4
+        uses: actions/deploy-pages@cd2ce8fcbc39b97be8ca5fce6e763baed58fa128 # v5.0.0

--- a/.github/workflows/pr-labeler.yaml
+++ b/.github/workflows/pr-labeler.yaml
@@ -12,7 +12,7 @@ jobs:
   label:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/labeler@v5
+      - uses: actions/labeler@f27b608878404679385c85cfa523b85ccb86e213 # v6.1.0
         with:
           configuration-path: .github/pr-labeler.yaml
           sync-labels: true

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -17,9 +17,9 @@ jobs:
       pull-requests: write
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Run tagpr
-        uses: Songmu/tagpr@3dca11e7c0d68637ee212ddd35acc3d30a7403a4 # v1.5.0
+        uses: Songmu/tagpr@555e72cee68c09d43dc2337dc9ba890955b630da # v1.19.0
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         id: run-tagpr
@@ -35,16 +35,16 @@ jobs:
       contents: write
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
           fetch-tags: true
       - name: Setup Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
           go-version-file: go.mod
       - name: Run GoReleaser
-        uses: goreleaser/goreleaser-action@v6
+        uses: goreleaser/goreleaser-action@5daf1e915a5f0af01ddbcd89a43b8061ff4f1a89 # v7.2.2
         with:
           version: '~> v2'
           args: release --clean


### PR DESCRIPTION
## WHAT

Pin every third-party GitHub Actions reference in `.github/workflows/*.yaml` to a full-length commit SHA, with the human-readable tag retained as a trailing comment. Actions are also bumped to their latest stable versions in the process.

## WHY

The repository's organization policy now requires all actions to be pinned to a full-length commit SHA. Workflows on the current `main` use floating tag references (`@v4`, `@v5`, etc.), so every job fails at `Set up job` with:

```
The actions actions/checkout@v4, actions/setup-go@v5, and golangci/golangci-lint-action@v7
are not allowed in babarot/gomi because all actions must be pinned to a full-length commit SHA.
```

This blocks CI on every PR (e.g. #127). Pinning to SHAs also mitigates supply chain risk: a compromised maintainer or tag re-point cannot silently change what runs in our pipelines.

## HOW

Run `PINACT_MIN_AGE=7 pinact run -u` to update each action to the latest release that is at least 7 days old (the cooldown mitigates a freshly published malicious version) and rewrite the reference to `<owner>/<action>@<sha> # <version>`.

Affected workflows: `build.yaml`, `label-sync.yaml`, `pages.yaml`, `pr-labeler.yaml`, `release.yaml`.

Notable version bumps included alongside the SHA pinning:

- `actions/checkout` v4 → v6.0.2
- `actions/setup-go` v5 → v6.4.0
- `golangci/golangci-lint-action` v7 → v9.2.1
- `actions/setup-python` v5 → v6.2.0
- `actions/upload-pages-artifact` v3 → v5.0.0
- `actions/deploy-pages` v4 → v5.0.0
- `actions/labeler` v5 → v6.1.0
- `goreleaser/goreleaser-action` v6 → v7.2.2
- `Songmu/tagpr` v1.5.0 → v1.19.0
- `EndBug/label-sync` v2 → v2.3.3
- `Schneegans/dynamic-badges-action` v1.7.0 → v1.8.0
- `k1LoW/octocov-action` v1.5.0 → v1.5.1

Validation is delegated to CI on this PR: the build/lint/release jobs need to come back green to confirm the major bumps (notably `golangci-lint-action` v7 → v9) do not require workflow changes.