### PR TITLE
Allow --prune to skip confirmation with -f

### DIFF
--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -53,7 +53,7 @@ type RmOption struct {
 	Interactive bool `short:"i" description:"(dummy) prompt before every removal"`
 	Recursive   bool `short:"r" long:"recursive" description:"(dummy) remove directories and their contents recursively"`
 	Recursive2  bool `short:"R" description:"(dummy) same as -r"`
-	Force       bool `short:"f" long:"force" description:"(dummy) ignore nonexistent files, never prompt"`
+	Force       bool `short:"f" long:"force" description:"ignore nonexistent files, never prompt (effective with --prune)"`
 	Directory   bool `short:"d" long:"dir" description:"(dummy) remove empty directories"`
 	Verbose     bool `short:"v" long:"verbose" description:"(dummy) explain what is being done"`
 }

--- a/internal/cli/prune.go
+++ b/internal/cli/prune.go
@@ -111,26 +111,28 @@ func (c *CLI) permanentlyDeleteByTimeRange(durations []time.Duration) error {
 		return nil
 	}
 
-	table.PrintFiles(filesToDelete, table.PrintOptions{
-		ShowRelativeTime: true,
-		Order:            table.SortDesc,
-	})
-	fmt.Println()
-	printDeletionSummary(filesToDelete, newestAge, oldestAge, len(durations) == 1)
+	if !c.option.Rm.Force {
+		table.PrintFiles(filesToDelete, table.PrintOptions{
+			ShowRelativeTime: true,
+			Order:            table.SortDesc,
+		})
+		fmt.Println()
+		printDeletionSummary(filesToDelete, newestAge, oldestAge, len(durations) == 1)
 
-	// First confirmation
-	if !c.prompter.Confirm(fmt.Sprintf("Are you sure you want to remove these %d files?", len(filesToDelete))) {
-		fmt.Println("Operation canceled.")
-		return nil
-	}
+		// First confirmation
+		if !c.prompter.Confirm(fmt.Sprintf("Are you sure you want to remove these %d files?", len(filesToDelete))) {
+			fmt.Println("Operation canceled.")
+			return nil
+		}
 
-	// Second confirmation with warning
-	fmt.Println()
-	// WARNING: Files will be permanently deleted and CANNOT be recovered. Are you absolutely sure?
-	fmt.Printf("%s\n", color.New(color.FgHiRed).Sprint("WARNING: This operation is permanent and cannot be undone!"))
-	if !c.prompter.ConfirmYes("Do you really want to permanently delete these files?") {
-		fmt.Println("Operation canceled.")
-		return nil
+		// Second confirmation with warning
+		fmt.Println()
+		// WARNING: Files will be permanently deleted and CANNOT be recovered. Are you absolutely sure?
+		fmt.Printf("%s\n", color.New(color.FgHiRed).Sprint("WARNING: This operation is permanent and cannot be undone!"))
+		if !c.prompter.ConfirmYes("Do you really want to permanently delete these files?") {
+			fmt.Println("Operation canceled.")
+			return nil
+		}
 	}
 
 	// Remove files


### PR DESCRIPTION
## WHAT

Make `gomi --prune=<duration>` skip the two confirmation prompts (and the file listing table) when `-f`/`--force` is passed. The existing `--prune=orphans` path already honors `-f`; this aligns the duration-based path with the same behavior.

Also drop the `(dummy)` marker from the `-f`/`--force` flag description, since the flag now has real effect under `--prune`.

Related: #126

## WHY

Requested in #126 for scripting use cases. The user wants to run prune non-interactively from init scripts, for example:

```sh
[[ "$(tty)" == /dev/tty1 ]] && gomi -V > /dev/null && gomi --prune=30d -f
```

Today the duration-based prune always asks twice, so it cannot be used unattended. Reusing the existing `-f` flag avoids adding a new option, keeps parity with the orphans path, and matches what `rm -f` does conceptually.

Implementation gates the existing prompt block in `permanentlyDeleteByTimeRange` on `!c.option.Rm.Force`. When `-f` is not set, behavior is unchanged: files are listed, summary is printed, and both confirmations are required. When `-f` is set, gomi proceeds straight to deletion.

Verified manually: with backdated trashinfo files, `gomi --prune=30d -f` deletes matches without prompting, while `gomi --prune=30d` still shows the table and prompts as before. `go test ./internal/cli/...` passes.